### PR TITLE
Add dictionary toggle support to auto-corrections

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -29,6 +29,10 @@ export interface CorrectionFix {
   confidence: CorrectionConfidence;
 }
 
+export interface AutoCorrectionOptions {
+  enableDictionarySuggestions?: boolean;
+}
+
 interface ParsedNPC {
   name: string;
   fields: Record<string, string>;
@@ -167,8 +171,12 @@ export function generateBatchTemplate(): string {
   ].join('\n');
 }
 
-export function generateAutoCorrectionFixes(input: string): CorrectionFix[] {
+export function generateAutoCorrectionFixes(
+  input: string,
+  options: AutoCorrectionOptions = {},
+): CorrectionFix[] {
   const fixes: CorrectionFix[] = [];
+  const { enableDictionarySuggestions = true } = options;
 
   const alignmentRegex = /(Alignment\s*:\s*)([^\n]+)/gi;
   let match: RegExpExecArray | null;
@@ -210,7 +218,7 @@ export function generateAutoCorrectionFixes(input: string): CorrectionFix[] {
 
   const italicsRegex = /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b/g;
   const spells = dictionaries.spells;
-  if (spells.size > 0) {
+  if (enableDictionarySuggestions && spells.size > 0) {
     let italicMatch: RegExpExecArray | null;
     while ((italicMatch = italicsRegex.exec(input)) !== null) {
       const candidate = italicMatch[1];
@@ -236,9 +244,14 @@ export function applyCorrectionFix(input: string, fix: CorrectionFix): string {
   return input.replace(fix.originalText, fix.correctedText);
 }
 
-export function applyAllHighConfidenceFixes(input: string): string {
+export function applyAllHighConfidenceFixes(
+  input: string,
+  options?: AutoCorrectionOptions,
+): string {
   let working = input;
-  const fixes = generateAutoCorrectionFixes(input).filter((fix) => fix.confidence === 'high');
+  const fixes = generateAutoCorrectionFixes(input, options).filter(
+    (fix) => fix.confidence === 'high',
+  );
   for (const fix of fixes) {
     working = applyCorrectionFix(working, fix);
   }


### PR DESCRIPTION
## Summary
- add auto-correction options so dictionary-backed suggestions can be toggled off
- pass the dictionary switch state through input processing and normalization handlers so auto-fixes respect the toggle

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d332649d44832fa3e3d85915eedbe4