### PR TITLE
Fix mount stats array typing

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -591,7 +591,7 @@ function parseBlock(block: string): ParsedNPC {
       const acMatch = mountData.match(/AC\s*(\d+)/i);
       const attackMatch = mountData.match(/(with\s+[^.]+attack[^.]*)/i);
 
-      const mountStats = [];
+      const mountStats: string[] = [];
       if (hdMatch) mountStats.push(`HD ${hdMatch[1]}`);
       if (hpMatch) mountStats.push(`HP ${hpMatch[1]}`);
       if (acMatch) mountStats.push(`AC ${acMatch[1]}`);


### PR DESCRIPTION
## Summary
- annotate the mount stats array in `npc-parser` as `string[]` so pushes of derived stats compile under TypeScript

## Testing
- npm run build *(fails: unable to download Google Fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d491e3cae8832f97a8a29fa5b27937