### PR TITLE
Remove debug logging from enhanced parser

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -151,7 +151,6 @@ export function extractParentheticalData(parenthetical: string): ParentheticalDa
       const charClass = proseMatch[3].replace(/s$/, ''); // Remove plural 's'
       data.raceClass = `${race}, ${level}${getSuperscriptOrdinal(level)} level ${charClass}`;
       data.level = level;
-      console.log('DEBUG: Prose match found:', { level, race, charClass, raceClass: data.raceClass });
     }
   }
 


### PR DESCRIPTION
## Summary
- remove a leftover debug log from the enhanced parser to keep production output clean

## Testing
- npm test *(fails: known expectation mismatches around superscript ordinals, canonical vital stats phrasing, and magic item italicization)*

------
https://chatgpt.com/codex/tasks/task_e_68d82b3e67b0832f8dc48a80a53d6643