### PR TITLE
Add build metadata footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CNC NPC Stat Block Parser and App (Next.js/React)",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NEXT_PUBLIC_COMMIT_HASH=\"$(git rev-parse --short HEAD)\" NEXT_PUBLIC_BUILD_DATE=\"$(date -u)\" next build",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "vitest run"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,6 +249,9 @@ Gender: he leads his troops
 Background: This sixteenth level fighter serves as captain`;
 
 function App() {
+  const COMMIT = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';
+  const BUILT = process.env.NEXT_PUBLIC_BUILD_DATE ?? 'local';
+
   const [appliedFixes, setAppliedFixes] = useState<string[]>([]);
   const [inputText, setInputText] = useState('');
   const [results, setResults] = useState<ProcessedNPC[]>([]);
@@ -1063,9 +1066,25 @@ function App() {
               <div className="flex items-center gap-2">
                 <span>Castles & Crusades NPC Stat Block Generator</span>
               </div>
-              <div className="flex items-center gap-1 font-mono text-xs">
-                <span className="text-foreground/40">Build:</span>
-                <span className="text-foreground/60">{formatVersionString()}</span>
+              <div className="flex flex-wrap items-center justify-center gap-3 font-mono text-xs text-foreground/60 sm:justify-end">
+                <span className="flex items-center gap-2">
+                  <span className="uppercase tracking-wide text-foreground/40">Build:</span>
+                  <code className="rounded border border-white/10 bg-white/5 px-2 py-1 text-foreground/70">
+                    {formatVersionString()}
+                  </code>
+                </span>
+                <span className="flex items-center gap-2">
+                  <span className="uppercase tracking-wide text-foreground/40">Commit:</span>
+                  <code className="rounded border border-white/10 bg-white/5 px-2 py-1 text-foreground/70">
+                    {COMMIT}
+                  </code>
+                </span>
+                <span className="flex items-center gap-2">
+                  <span className="uppercase tracking-wide text-foreground/40">Built:</span>
+                  <code className="rounded border border-white/10 bg-white/5 px-2 py-1 text-foreground/70" title={BUILT}>
+                    {BUILT}
+                  </code>
+                </span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- expose commit hash and build timestamp in the app footer with safe client defaults
- wire the Next.js build script to inject the current commit hash and build time so the UI receives real values

## Testing
- ./node_modules/.bin/next build && ./node_modules/.bin/next start *(fails: Next.js cannot download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d82b3d1af8832f8d1c576395367dc1