### PR TITLE
Fix type narrowing for unified report rendering

### DIFF
--- a/src/lib/unified-report.ts
+++ b/src/lib/unified-report.ts
@@ -155,6 +155,10 @@ function formatBalanceSnapshot(snapshot: BalanceMeterReading): string {
   return pieces.join(' ');
 }
 
+function isPersonalReport(report: UnifiedReport): report is PersonalUnifiedReport {
+  return report.metadata.kind === 'personal';
+}
+
 function renderPersonalReport(report: PersonalUnifiedReport): string[] {
   const { blueprint, weather, growthEdges, integration } = report;
   const modes = blueprint.modes;
@@ -257,7 +261,7 @@ function renderTransits(transits: TransitSection): string[] {
 }
 
 export function renderUnifiedReport(report: UnifiedReport): string[] {
-  return report.metadata.kind === 'personal'
+  return isPersonalReport(report)
     ? renderPersonalReport(report)
     : renderRelationalReport(report);
 }


### PR DESCRIPTION
## Summary
- add a type guard to distinguish personal unified reports from relational ones
- use the new type guard when rendering unified reports to satisfy TypeScript

## Testing
- npm run build *(fails: unable to download Google Fonts during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b6c2556c832fa35318f5f351bd47