### PR TITLE
Fix build by using local Geist fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.5.2",
     "framer-motion": "^12.6.2",
+    "geist": "^1.5.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.484.0",
     "mammoth": "^1.11.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,10 @@
 import type { ReactNode } from "react";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 
 import "./globals.css";
 
 // Font loading with comprehensive fallbacks for offline environments
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  fallback: ["ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "sans-serif"],
-  display: "swap",
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-  fallback: ["ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
-  display: "swap",
-});
-
 export const metadata = {
   title: "C&C NPC and Monster Parser",
   description: "Comprehensive stat block validator for Castles & Crusades NPCs and monsters",
@@ -31,7 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >
         {children}
       </body>


### PR DESCRIPTION
## Summary
- import Geist fonts from the local `geist` package instead of Google Fonts so builds no longer fetch external assets
- add the `geist` dependency to provide the bundled font files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8baea0884832fbf796aafcfa1aaf1