### PR TITLE
Refine canonical unit descriptors

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -746,7 +746,7 @@ function buildDescriptorFromData(data: ParentheticalData, isUnit: boolean, title
   if (isUnit) {
     if (race && level && charClass) {
       const ordinal = `${level}${getSuperscriptOrdinal(level)}`;
-      return `${subject} ${race} ${ordinal} level ${pluralizeClassNameLocal(charClass)}`.replace(/\s+/g, ' ').trim();
+      return `${subject} ${ordinal} level ${race} ${pluralizeClassNameLocal(charClass)}`.replace(/\s+/g, ' ').trim();
     }
 
     if (race && charClass) {
@@ -767,7 +767,7 @@ function buildDescriptorFromData(data: ParentheticalData, isUnit: boolean, title
   } else {
     if (race && level && charClass) {
       const ordinal = `${level}${getSuperscriptOrdinal(level)}`;
-      return `${subject} ${race}, ${ordinal} level ${charClass}`.replace(/\s+/g, ' ').trim();
+      return `${subject} ${ordinal} level ${race} ${charClass}`.replace(/\s+/g, ' ').trim();
     }
 
     if (race && charClass) {
@@ -794,9 +794,6 @@ export function buildCanonicalParenthetical(data: ParentheticalData, isUnit: boo
   const coinsText = data.coins ? canonicalizeCoinsText(data.coins) : undefined;
   let coinsIncludedInWeapons = false;
 
-  // If the original input already had a proper sentence with pronoun, avoid duplication
-  const hasOriginalPronoun = data.originalPronoun && ['these', 'this', 'the'].includes(data.originalPronoun);
-
   // Build vital stats
   const vitalParts: string[] = [];
   if (data.hp) vitalParts.push(`HP ${data.hp}`);
@@ -804,7 +801,7 @@ export function buildCanonicalParenthetical(data: ParentheticalData, isUnit: boo
   if (data.disposition) vitalParts.push(`disposition ${data.disposition.toLowerCase()}`);
 
   if (vitalParts.length > 0) {
-    let descriptor = '';
+    let descriptorData = { ...data };
 
     if (data.raceClass) {
       let raceClassText = data.raceClass;
@@ -823,37 +820,10 @@ export function buildCanonicalParenthetical(data: ParentheticalData, isUnit: boo
         raceClassText = classLevelMatch ? classLevelMatch[0] : raceClassText;
       }
 
-      // Build descriptor with disposition first, then race/class
-      let descriptorParts: string[] = [];
-
-      // Add disposition first if available
-      if (data.disposition) {
-        descriptorParts.push(data.disposition);
-      }
-
-      // Add race/class text
-      descriptorParts.push(raceClassText);
-
-      const combinedText = descriptorParts.join(' ');
-
-      if (hasOriginalPronoun) {
-        // Original had proper pronoun structure, use it directly to avoid duplication
-        const properPronoun = data.originalPronoun === 'these' ? 'These' :
-                             data.originalPronoun === 'this' ? 'This' : 'The';
-        descriptor = `${properPronoun} ${combinedText}`;
-      } else {
-        // No original pronoun, use standard format
-        if (isUnit) {
-          descriptor = `These ${combinedText}`;
-        } else {
-          descriptor = `This ${combinedText}`;
-        }
-      }
-    } else {
-      // Fallback for unknown creatures
-      descriptor = isUnit ? 'These creatures' : 'This creature';
+      descriptorData = { ...descriptorData, raceClass: raceClassText };
     }
 
+    const descriptor = buildDescriptorFromData(descriptorData, isUnit);
     const possessive = formatPossessiveDescriptor(descriptor, isUnit);
     parts.push(`${possessive} vital stats are ${vitalParts.join(', ')}`);
   }
@@ -938,7 +908,7 @@ export function buildCanonicalParenthetical(data: ParentheticalData, isUnit: boo
 
       // Add coins with proper conjunction
       if (coinsText) {
-        weaponList += `, and ${coinsText}`;
+        weaponList += `, and carry ${coinsText}`;
         coinsIncludedInWeapons = true;
       }
 

--- a/src/test/enhanced-parser.test.ts
+++ b/src/test/enhanced-parser.test.ts
@@ -189,9 +189,9 @@ describe('Enhanced Parser Functions', () => {
         raw: 'original'
       };
 
-      const result = buildCanonicalParenthetical(data, false, true, false);
+      const result = buildCanonicalParenthetical(data, false, false, false);
 
-      expect(result).toContain('This neutral 4th level fighter’s vital stats are HP 24, AC 16, disposition neutral, his primary attributes are strength, dexterity, constitution, he wears banded mail and carries medium steel shield, longsword, and dagger.');
+      expect(result).toContain('This 4ᵗʰ level human fighter’s vital stats are HP 24, AC 16, disposition neutral, his primary attributes are strength, dexterity, constitution, he wears banded mail and carries medium steel shield, longsword, and dagger.');
     });
 
     it('should build canonical format for unit', () => {
@@ -207,10 +207,10 @@ describe('Enhanced Parser Functions', () => {
       };
 
 
-      const result = buildCanonicalParenthetical(data, true, true, false);
+      const result = buildCanonicalParenthetical(data, true, false, false);
 
 
-      expect(result).toContain('These neutral 2nd level fighters’ vital stats are HP 12, AC 15, disposition neutral, their primary attributes are physical, they wear chain mail and carry longbows and longswords.');
+      expect(result).toContain('These 2ⁿᵈ level human fighters’ vital stats are HP 12, AC 15, disposition neutral, their primary attributes are physical, they wear chain mail and carry longbows and longswords.');
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure canonical descriptors for NPCs and units lead with level/race information without duplicating disposition text
- adjust coin handling so weapon lists conclude with the mandated carry phrasing and preserve superscript ordinals in descriptors
- update enhanced parser tests to validate the new canonical wording for individuals and troop blocks

## Testing
- npm test -- src/test/enhanced-parser.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8f5915f90832f832696944a02a7fc