### PR TITLE
Use const for equipment regex match

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -367,7 +367,7 @@ export function extractParentheticalData(parenthetical: string, isUnit: boolean 
   }
 
   // Extract equipment - preserve verb structure when possible, including conditional equipment
-  let equipMatch = /(?:EQ|equipment)[\s:-]+([^.;]+)/i.exec(parenthetical);
+  const equipMatch = /(?:EQ|equipment)[\s:-]+([^.;]+)/i.exec(parenthetical);
   if (equipMatch) {
     data.equipment = equipMatch[1].trim();
   } else {


### PR DESCRIPTION
## Summary
- switch the equipment regex match variable in the enhanced parser to `const` because it is never reassigned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc5264e7e4832faacfc34d8af9f04c