### PR TITLE
Refine attribute normalization rules for parser

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -474,8 +474,14 @@ function parseBlockEnhanced(block: string): ParsedNPC {
     if (cleanedData.raceClass) fields['Race & Class'] = cleanedData.raceClass;
 
     if (cleanedData.attributes) {
-      const normalized = normalizeAttributes(cleanedData.attributes, isUnit);
-      fields['Primary attributes'] = normalized;
+      const normalized = normalizeAttributes(cleanedData.attributes, {
+        isUnit,
+        raceClassText: cleanedData.raceClass,
+        levelText: cleanedData.level
+      });
+      if (normalized.type !== 'none' && normalized.value) {
+        fields['Primary attributes'] = normalized.value;
+      }
     }
 
     if (cleanedData.equipment) {


### PR DESCRIPTION
## Summary
- overhaul attribute normalization to detect modifier-qualified scores, honor 1st-level fighter primes, and emit prime descriptions for units or classless creatures
- update canonical parenthetical construction to use the richer attribute result, adjust unit armor detection for leather gear, and avoid storing empty attribute data
- extend enhanced parser tests to cover the new attribute thresholds, unit primes, and classless handling scenarios

## Testing
- npm test -- src/test/enhanced-parser.test.ts
- npm test -- test-equipment-fix.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc57c4c870832f87af75a9d4959722