### PR TITLE
Allow abbreviated coinage references

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -86,13 +86,9 @@ function canonicalizeCoinsText(coins: string): string {
 
   let normalized = coins.trim();
 
-  normalized = normalized.replace(/(\d+)\s*[–-]\s*(\d+)/g, (_, start, end) => {
-    const startNum = parseInt(start, 10);
-    const endNum = parseInt(end, 10);
-    return `${numberToWords(startNum)} to ${numberToWords(endNum)}`;
-  });
-
-  normalized = normalized.replace(/\b(\d+)\b/g, (_, value) => numberToWords(parseInt(value, 10)));
+  normalized = normalized.replace(/\s*[-–]\s*/g, '–');
+  normalized = normalized.replace(/(\d)(pp|gp|sp|cp)\b/gi, '$1 $2');
+  normalized = normalized.replace(/\s+/g, ' ');
 
   return normalized;
 }
@@ -423,9 +419,9 @@ export function extractParentheticalData(parenthetical: string, isUnit: boolean 
     if (isMilitaryUnit && !data.coins && data.level) {
       const level = parseInt(data.level);
       if (level === 1) {
-        data.coins = '1–6 gold in coin';
+        data.coins = '1–6 gp';
       } else if (level <= 3) {
-        data.coins = `${level}–${level * 6} gold in coin`;
+        data.coins = `${level}–${level * 6} gp`;
       }
     }
   }
@@ -433,7 +429,7 @@ export function extractParentheticalData(parenthetical: string, isUnit: boolean 
   // Extract coins with multiple pattern variations
   const coinMatch = /(\d+)[-–](\d+)\s*(?:gp|gold|GP)/i.exec(parenthetical);
   if (coinMatch) {
-    data.coins = `${coinMatch[1]}–${coinMatch[2]} gold in coin`;
+    data.coins = `${coinMatch[1]}–${coinMatch[2]} gp`;
   }
 
   // Extract significant attributes with values
@@ -475,19 +471,19 @@ export function extractParentheticalData(parenthetical: string, isUnit: boolean 
       switch (type) {
         case 'gp':
         case 'gold':
-          currencies.push(`${amount} gold in coin`);
+          currencies.push(`${amount} gp`);
           break;
         case 'sp':
         case 'silver':
-          currencies.push(`${amount} silver in coin`);
+          currencies.push(`${amount} sp`);
           break;
         case 'cp':
         case 'copper':
-          currencies.push(`${amount} copper in coin`);
+          currencies.push(`${amount} cp`);
           break;
         case 'pp':
         case 'platinum':
-          currencies.push(`${amount} platinum in coin`);
+          currencies.push(`${amount} pp`);
           break;
       }
     }

--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -1614,12 +1614,6 @@ export function collapseNPCEntry(input: string): string {
 export function findEquipment(equipment: string): string {
   let processed = equipment;
 
-  // Expand coinage abbreviations
-  processed = processed.replace(/(\d+)\s*pp\b/gi, '$1 platinum');
-  processed = processed.replace(/(\d+)\s*gp\b/gi, '$1 gold');
-  processed = processed.replace(/(\d+)\s*sp\b/gi, '$1 silver');
-  processed = processed.replace(/(\d+)\s*cp\b/gi, '$1 copper');
-
   // Apply comprehensive magic item name mappings
   for (const [old, replacement] of Object.entries(MAGIC_ITEM_MAPPINGS)) {
     processed = processed.replace(new RegExp(old, 'gi'), replacement);

--- a/test-equipment-fix.test.ts
+++ b/test-equipment-fix.test.ts
@@ -33,8 +33,8 @@ describe('Equipment Processing Edge Cases', () => {
     console.log('Currency input:', currencyInput);
     console.log('Currency result:', result[0].converted);
 
-    expect(result[0].converted).toContain('gold');
-    expect(result[0].converted).toContain('silver');
-    expect(result[0].converted).toContain('platinum');
+    expect(result[0].converted).toContain('10 gp');
+    expect(result[0].converted).toContain('5 sp');
+    expect(result[0].converted).toContain('2 pp');
   });
 });


### PR DESCRIPTION
## Summary
- stop expanding currency abbreviations when formatting equipment
- update enhanced parser coin handling to prefer gp/sp/cp/pp strings and new defaults
- adjust currency-focused test expectation to reflect abbreviated output

## Testing
- npm test *(fails: unrelated pre-existing assertions in npc parser and race/class tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5dc1d848832f8662195bb0209fde