### PR TITLE
Apply name mappings before magic item mechanics

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -26,7 +26,7 @@ export interface ParsedTitleAndBody {
   parentheticals: string[];
 }
 
-import { addMagicItemMechanics } from './name-mappings';
+import { addMagicItemMechanics, applyNameMappings } from './name-mappings';
 
 export interface MountBlock {
   name: string;
@@ -1047,16 +1047,17 @@ export function buildCanonicalParenthetical(data: ParentheticalData, isUnit: boo
       }
 
       // Process magic items
-      let processedPart = part;
-      if (/\+\d+|staff of|sword of|ring of|robe of|cloak of|boots of|gauntlets of|helm of|bracers of|pectoral of/i.test(part)) {
-        processedPart = addMagicItemMechanics(part);
-      }
+      let processedPart = applyNameMappings(part);
 
-      // Apply block-level italics to ALL gear (Jeremy's Fiat)
-      processedPart = `*${processedPart}*`;
+      if (/\+\d+|staff of|sword of|ring of|robe of|cloak of|boots of|gauntlets of|helm of|bracers of|pectoral of/i.test(processedPart)) {
+        processedPart = addMagicItemMechanics(processedPart);
+      }
 
       processedPart = processedPart.replace(/^(?:and\s+)?(?:they|he|she|it)\s+/i, '');
       processedPart = processedPart.replace(/^(?:and\s+)?(?:wears|wear|carries|carry)\s+/i, '');
+
+      // Apply block-level italics to ALL gear (Jeremy's Fiat)
+      processedPart = `*${processedPart}*`;
 
       // For units, pluralize items
       if (isUnit) {

--- a/src/lib/name-mappings.ts
+++ b/src/lib/name-mappings.ts
@@ -548,14 +548,7 @@ export function addMagicItemMechanics(item: string): string {
     return `${item}—${MAGIC_ITEM_MECHANICS[lowerItem]}`;
   }
 
-  // Handle +X bonuses for specific items - only add the bonus, not generic mechanics
   const bonusMatch = item.match(/\+(\d+)/);
-  if (bonusMatch) {
-    const bonus = bonusMatch[1];
-    if (MAGIC_ITEM_MECHANICS[`+${bonus}`]) {
-      return `${item}—${MAGIC_ITEM_MECHANICS[`+${bonus}`]}`;
-    }
-  }
 
   // Check for partial matches (but avoid double-matching shields with bonuses)
   for (const [itemName, mechanics] of Object.entries(MAGIC_ITEM_MECHANICS)) {
@@ -565,6 +558,14 @@ export function addMagicItemMechanics(item: string): string {
         continue;
       }
       return `${item}—${mechanics}`;
+    }
+  }
+
+  // Handle +X bonuses for specific items - only add the bonus, not generic mechanics
+  if (bonusMatch) {
+    const bonus = bonusMatch[1];
+    if (MAGIC_ITEM_MECHANICS[`+${bonus}`]) {
+      return `${item}—${MAGIC_ITEM_MECHANICS[`+${bonus}`]}`;
     }
   }
 

--- a/test-equipment-fix.test.ts
+++ b/test-equipment-fix.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { processDumpEnhanced } from './src/lib/npc-parser';
+import { buildCanonicalParenthetical } from './src/lib/enhanced-parser';
 
 describe('Equipment Processing Edge Cases', () => {
   it('should handle unit equipment verbs correctly', () => {
@@ -36,5 +37,19 @@ describe('Equipment Processing Edge Cases', () => {
     expect(result[0].converted).toContain('10 gp');
     expect(result[0].converted).toContain('5 sp');
     expect(result[0].converted).toContain('2 pp');
+  });
+
+  it('remaps magic items before adding mechanics', () => {
+    const parenthetical = buildCanonicalParenthetical(
+      {
+        equipment: 'ring of protection +5',
+        raw: 'ring of protection +5'
+      },
+      false
+    );
+
+    console.log('Ring parenthetical:', parenthetical);
+
+    expect(parenthetical).toContain('*ring of armor +5—AC +1 to +5*');
   });
 });


### PR DESCRIPTION
## Summary
- run equipment entries through applyNameMappings in the enhanced parser before decorating them with magic item mechanics and clean up verbs prior to italicization
- prioritize specific magic item mechanic mappings ahead of generic +X bonus fallbacks
- add a regression test covering ring of protection remapping and mechanic annotation

## Testing
- npm test *(fails: existing expectations around magic item formatting and race/class preservation)*

------
https://chatgpt.com/codex/tasks/task_e_68dc833c4020832fa9144c9e8dd0cbb3