### PR TITLE
Fix unnecessary escape characters in enhanced parser regex

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -305,7 +305,7 @@ export function extractParentheticalData(parenthetical: string, isUnit: boolean 
 
   // Try to extract from format like "He is a neutral evil, human, 4th/5th level fighter/assassin"
   if (!data.raceClass) {
-    const heIsPattern = /(he|she|it)\s+is\s+a\s+(.+?),\s*([a-z-]+),\s*([0-9\/thndrdst]+)\s+level\s+([a-z\/-]+)/i.exec(parenthetical);
+    const heIsPattern = /(he|she|it)\s+is\s+a\s+(.+?),\s*([a-z-]+),\s*([0-9/thndrdst]+)\s+level\s+([a-z/-]+)/i.exec(parenthetical);
     if (heIsPattern) {
       const pronoun = heIsPattern[1].toLowerCase();
       const disposition = heIsPattern[2];


### PR DESCRIPTION
## Summary
- remove unnecessary escaping of the slash character in the enhanced parser's "He is a" pattern to satisfy eslint's no-useless-escape rule

## Testing
- npm run lint *(fails: existing eslint errors unrelated to this change remain in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68df19c597d0832fb0b0cb45d0f47286