### PR TITLE
Improve monster parser handling of legacy inline fields

### DIFF
--- a/src/lib/monster-parser.ts
+++ b/src/lib/monster-parser.ts
@@ -96,7 +96,7 @@ const FIELD_ALIASES: FieldAlias[] = [
   },
   {
     field: 'Intelligence',
-    patterns: [buildFieldPattern('Intelligence')],
+    patterns: [buildFieldPattern('Intelligence'), buildFieldPattern('INT')],
   },
   {
     field: 'Size',
@@ -168,7 +168,7 @@ export function parseMonsterBlock(block: string): ParsedNPC {
       handled = true;
 
       if (alias.consumeRestOfLine) {
-        break;
+        continue;
       }
     }
 
@@ -282,15 +282,28 @@ function splitSegments(line: string): string[] {
       depth = Math.max(0, depth - 1);
     }
 
-    if (depth === 0 && (char === ',' || char === ';')) {
-      const remainder = line.slice(i + 1).trim();
-      if (remainder && looksLikeFieldStart(remainder)) {
-        push();
-        continue;
-      }
+    current += char;
+
+    if (depth > 0) {
+      continue;
     }
 
-    current += char;
+    const remainder = line.slice(i + 1);
+    if (!remainder) {
+      continue;
+    }
+
+    const trimmedRemainder = remainder.replace(/^[\s,;]+/, '');
+    if (!trimmedRemainder) {
+      continue;
+    }
+
+    if (looksLikeFieldStart(trimmedRemainder)) {
+      push();
+      const consumed = remainder.length - trimmedRemainder.length;
+      i += consumed;
+      continue;
+    }
   }
 
   push();
@@ -303,15 +316,7 @@ function cleanValue(value: string): string {
 
 function buildFieldPattern(label: string): RegExp {
   const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
-
-  const suffix = '(?:\\s*[.:;–—-])?\\s*';
-  return new RegExp(`^${escaped}${suffix}`, 'i');
-
-  return new RegExp(String.raw`^${escaped}(?:\s*[.:;–—-])?\s*`, 'i');
-
-  return new RegExp(`^${escaped}(?:\s*[.:;–—-])?\s*`, 'i');
-
-
+  return new RegExp(`^${escaped}\\b(?:\\s*[.:;–—-])?\\s*`, 'i');
 }
 
 function sanitizeName(lines: string[]): string {

--- a/test-monster-parser.test.ts
+++ b/test-monster-parser.test.ts
@@ -61,6 +61,33 @@ describe('monster parser', () => {
     expect(parsed.fields['Special Abilities']).toMatch(/restrained/);
   });
 
+  it('parses legacy inline uppercase field sequences without delimiters', () => {
+    const legacyBlock = [
+      'TURTLE, HUGE SNAPPING NO. ENCOUNTERED: 1',
+      'SIZE: Large HD: 5 (d8)',
+      'MOVE: 3 feet on land, 6 feet swimming AC: 19 shell, 12 head, limbs and tail ATTACKS: Bite (2d4+10)',
+      'SPECIAL: Continuing Damage SAVES: P',
+      'INT: Animal ALIGNMENT: Neutral TYPE: Animal TREASURE: Nil',
+      'XP: 100+5',
+    ].join('\n');
+
+    const parsed = parseMonsterBlock(legacyBlock);
+
+    expect(parsed.name).toBe('TURTLE, HUGE SNAPPING NO. ENCOUNTERED: 1');
+    expect(parsed.fields['Size']).toBe('Large');
+    expect(parsed.fields['HD']).toBe('5 (d8)');
+    expect(parsed.fields['Move']).toBe('3 feet on land, 6 feet swimming');
+    expect(parsed.fields['AC']).toBe('19 shell, 12 head, limbs and tail');
+    expect(parsed.fields['Attacks']).toBe('Bite (2d4+10)');
+    expect(parsed.fields['Special Abilities']).toBe('Continuing Damage');
+    expect(parsed.fields['Saves']).toBe('P');
+    expect(parsed.fields['Intelligence']).toBe('Animal');
+    expect(parsed.fields['Disposition']).toBe('neutral');
+    expect(parsed.fields['Type']).toBe('Animal');
+    expect(parsed.fields['Treasure']).toBe('Nil');
+    expect(parsed.fields['XP']).toBe('100+5');
+  });
+
   it('splits multi-block dumps and integrates with formatting + validation', () => {
     const dump = `${ORC_BLOCK}\n\n**Goblin Sentry**\nHD 1d6, AC 14, Move 30 ft\nAttacks: spear +1 (1d6)\nSaves: P\nType: Humanoid\nTreasure: 1d4 gp\nXP: 20\nAlignment: Neutral Evil`;
     const monsters = parseMonsterBlocks(dump);


### PR DESCRIPTION
## Summary
- update the monster parser to split inline legacy field sequences and recognise INT aliases when parsing monsters
- adjust field matching to respect word boundaries so AC patterns do not trigger within other labels
- add a regression test covering the Huge Snapping Turtle legacy stat block format

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e2f0ad01e4832fb847f8d1445b020d