### PR TITLE
Fix lint regressions blocking Vercel build

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
 // Font loading with comprehensive fallbacks for offline environments
+// eslint-disable-next-line react-refresh/only-export-components
 export const metadata = {
   title: "C&C NPC and Monster Parser",
   description: "Comprehensive stat block validator for Castles & Crusades NPCs and monsters",

--- a/src/components/DocumentAnalyzer.tsx
+++ b/src/components/DocumentAnalyzer.tsx
@@ -5,19 +5,16 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
-import { Progress } from '@/components/ui/progress';
 import { Separator } from '@/components/ui/separator';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   FileText,
-  Upload,
   Download,
   Copy,
   ChevronDown,
   ChevronRight,
   AlertTriangle,
   CheckCircle,
-  Info,
   BarChart3,
   FileCheck,
   AlertCircle,
@@ -26,10 +23,6 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { analyzeDocument, DocumentComplianceReport, generateDocumentReport } from '@/lib/document-analyzer';
-
-interface DocumentAnalyzerProps {
-  onClose?: () => void;
-}
 
 const EXAMPLE_DOCUMENT = `# Chapter 3: The Royal Court
 
@@ -91,7 +84,7 @@ HP: 12
 AC: 10
 Equipment: spell book, component pouch, 50 gp`;
 
-export function DocumentAnalyzer({ onClose }: DocumentAnalyzerProps) {
+export function DocumentAnalyzer() {
   const [documentText, setDocumentText] = useState('');
   const [documentName, setDocumentName] = useState('');
   const [report, setReport] = useState<DocumentComplianceReport | null>(null);
@@ -188,6 +181,7 @@ export function DocumentAnalyzer({ onClose }: DocumentAnalyzerProps) {
       await navigator.clipboard.writeText(reportText);
       toast.success('Report copied to clipboard');
     } catch (error) {
+      console.error('Failed to copy document analysis report to clipboard:', error);
       toast.error('Failed to copy report');
     }
   };

--- a/src/lib/document-analyzer.ts
+++ b/src/lib/document-analyzer.ts
@@ -1,4 +1,4 @@
-import { processDumpWithValidation, ProcessedNPC, ValidationResult, ValidationWarning } from './npc-parser';
+import { processDumpWithValidation, ProcessedNPC } from './npc-parser';
 
 export interface DocumentStatBlock {
   npc: ProcessedNPC;
@@ -47,7 +47,6 @@ const STAT_BLOCK_PATTERNS = [
 ];
 
 export function analyzeDocument(documentText: string, documentName: string = 'Untitled Document'): DocumentComplianceReport {
-  const lines = documentText.split(/\r?\n/);
   const statBlocks = extractStatBlocksFromDocument(documentText);
 
   if (statBlocks.length === 0) {
@@ -151,7 +150,7 @@ function extractStatBlocksFromDocument(documentText: string): DocumentStatBlock[
           });
         }
       } catch (error) {
-        // Skip malformed stat blocks
+        console.warn('Skipping malformed stat block segment:', error);
       }
 
       inStatBlock = false;
@@ -175,7 +174,7 @@ function extractStatBlocksFromDocument(documentText: string): DocumentStatBlock[
         });
       }
     } catch (error) {
-      // Skip malformed stat blocks
+      console.warn('Skipping malformed trailing stat block segment:', error);
     }
   }
 

--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -669,7 +669,7 @@ function extractClassInfo(raceClassText?: string, levelText?: string): { classNa
 }
 
 export function normalizeAttributes(attributes: string, options: NormalizeAttributeOptions = {}): NormalizedAttributesResult {
-  const { isUnit = false, raceClassText, levelText } = options;
+  const { raceClassText, levelText } = options;
   if (!attributes || !attributes.trim()) {
     return { type: 'none' };
   }
@@ -1109,7 +1109,6 @@ function formatSpellLevels(spellText: string): string {
 
 export function buildCanonicalParenthetical(data: ParentheticalData, isUnit: boolean, omitRace: boolean = false, useSuperscriptOrdinals: boolean = true, title?: string): string {
   const parts: string[] = [];
-  const subjectPronoun = isUnit ? 'they' : 'he';
   const wearVerb = isUnit ? 'wear' : 'wears';
   const carryVerb = isUnit ? 'carry' : 'carries';
   const coinsText = data.coins ? canonicalizeCoinsText(data.coins) : undefined;

--- a/src/lib/excel-import.ts
+++ b/src/lib/excel-import.ts
@@ -2,6 +2,25 @@
 // Utility to read Excel files and extract PC/NPC data for folders/rosters
 import * as XLSX from 'xlsx';
 
+interface RawCharacterRow {
+  id?: string;
+  ID?: string;
+  kind?: string;
+  Kind?: string;
+  name?: string;
+  Name?: string;
+  defense?: number | string;
+  Defense?: number | string;
+  threat?: number | string;
+  Threat?: number | string;
+  tier?: number | string;
+  Tier?: number | string;
+  status?: ExcelCharacter['status'];
+  Status?: ExcelCharacter['status'];
+  updatedAt?: string;
+  UpdatedAt?: string;
+}
+
 export interface ExcelCharacter {
   id: string;
   kind: 'PC' | 'NPC' | 'Monster';
@@ -16,15 +35,15 @@ export interface ExcelCharacter {
 export function parseExcelCharacters(file: ArrayBuffer): ExcelCharacter[] {
   const workbook = XLSX.read(file, { type: 'array' });
   const sheet = workbook.Sheets[workbook.SheetNames[0]];
-  const rows = XLSX.utils.sheet_to_json(sheet);
-  return rows.map((row: any) => ({
-    id: row.id || row.ID || '',
-    kind: row.kind || row.Kind || 'NPC',
-    name: row.name || row.Name || '',
-    defense: Number(row.defense || row.Defense || 0),
-    threat: row.threat ? Number(row.threat) : undefined,
-    tier: Number(row.tier || row.Tier || 1) as 1|2|3|4,
-    status: row.status || row.Status,
-    updatedAt: row.updatedAt || row.UpdatedAt || new Date().toISOString(),
+  const rows = XLSX.utils.sheet_to_json<RawCharacterRow>(sheet);
+  return rows.map((row) => ({
+    id: row.id ?? row.ID ?? '',
+    kind: (row.kind ?? row.Kind ?? 'NPC') as ExcelCharacter['kind'],
+    name: row.name ?? row.Name ?? '',
+    defense: Number(row.defense ?? row.Defense ?? 0),
+    threat: row.threat !== undefined || row.Threat !== undefined ? Number(row.threat ?? row.Threat ?? 0) : undefined,
+    tier: Number(row.tier ?? row.Tier ?? 1) as 1|2|3|4,
+    status: row.status ?? row.Status,
+    updatedAt: row.updatedAt ?? row.UpdatedAt ?? new Date().toISOString(),
   }));
 }

--- a/src/lib/monster-parser.ts
+++ b/src/lib/monster-parser.ts
@@ -303,15 +303,7 @@ function cleanValue(value: string): string {
 
 function buildFieldPattern(label: string): RegExp {
   const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
-
-  const suffix = '(?:\\s*[.:;–—-])?\\s*';
-  return new RegExp(`^${escaped}${suffix}`, 'i');
-
-  return new RegExp(String.raw`^${escaped}(?:\s*[.:;–—-])?\s*`, 'i');
-
-  return new RegExp(`^${escaped}(?:\s*[.:;–—-])?\s*`, 'i');
-
-
+  return new RegExp(`^${escaped}(?:\\s*[.:;–—-])?\\s*`, 'i');
 }
 
 function sanitizeName(lines: string[]): string {

--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -29,7 +29,7 @@ export interface AutoCorrectionOptions {
   enableDictionarySuggestions?: boolean;
 }
 
-import { MAGIC_ITEM_MAPPINGS, SPELL_NAME_MAPPINGS, applyNameMappings, addMagicItemMechanics } from './name-mappings';
+import { MAGIC_ITEM_MAPPINGS, addMagicItemMechanics } from './name-mappings';
 import {
   splitTitleAndBody,
   extractParentheticalData,
@@ -123,22 +123,6 @@ const RACE_PATTERN = new RegExp(`\\b(${KNOWN_RACES.map(escapeForPattern).join('|
 const CLASS_PATTERN = new RegExp(`\\b(${KNOWN_CLASSES.map(escapeForPattern).join('|')})s?\\b`, 'i');
 const LEVEL_PATTERN = /\b\d+(?:st|nd|rd|th)?\s+level\b/i;
 const GENDER_PATTERN = /\b(male|female)\b/i;
-
-const FIELD_ORDER = [
-  'Disposition',
-  'Race & Class',
-  'Hit Points (HP)',
-  'Armor Class (AC)',
-  'Primary attributes',
-  'Secondary Skills',
-  'Equipment',
-  'Spells',
-  'Mount',
-  'Gear',
-  'Special Abilities',
-  'Vision',
-  'Background',
-];
 
 const VALIDATION_RULES: Array<{
   field: string;
@@ -536,8 +520,7 @@ function parseBlockEnhanced(block: string): ParsedNPC {
   let mountBlock: string | undefined;
 
   // Process first parenthetical (main NPC data)
-  if (parentheticals.length > 0) {
-    const parentheticalData = extractParentheticalData(parentheticals[0], isUnit, title);
+    if (parentheticals.length > 0) {
 
     // Extract mount if present and clean parenthetical
     const { cleanedParenthetical, mountBlock: extractedMount } = extractMountFromParenthetical(parentheticals[0]);
@@ -547,7 +530,7 @@ function parseBlockEnhanced(block: string): ParsedNPC {
     }
 
     // Re-extract data from cleaned parenthetical
-    const cleanedData = extractParentheticalData(cleanedParenthetical, isUnit, title);
+      const cleanedData = extractParentheticalData(cleanedParenthetical, isUnit, title);
 
     // Map extracted data to fields
     if (cleanedData.hp) fields['Hit Points (HP)'] = cleanedData.hp;
@@ -1067,13 +1050,6 @@ function normalizeFieldLabel(label: string): string {
     'xp': 'XP',
   };
   return mapping[normalized] ?? capitalize(label.trim());
-}
-
-function formatFieldValue(field: string, value: string): string {
-  if (field === 'Disposition') {
-    return normalizeDisposition(value);
-  }
-  return value;
 }
 
 function capitalize(value: string): string {

--- a/src/pages/api/encounters/[id]/party/preview.ts
+++ b/src/pages/api/encounters/[id]/party/preview.ts
@@ -4,12 +4,37 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 // Example data sources (replace with DB or file source)
 // Note: Since the actual API endpoints export handlers, we'll use mock data here
-const folders = [
-  { id: 'adv1', kind: 'Adventure', name: 'The Sapphire Heist', memberIds: ['npc1','npc2','pc1'] },
-  { id: 'roster1', kind: 'Roster', name: 'Main Roster', memberIds: ['pc2','pc3','npc3'] },
+type CharacterKind = 'PC' | 'NPC' | 'Monster';
+
+interface Folder {
+  id: string;
+  kind: string;
+  name: string;
+  memberIds: string[];
+}
+
+interface Character {
+  id: string;
+  kind: CharacterKind;
+  name: string;
+  defense: number;
+  tier: number;
+  threat?: number;
+  updatedAt: string;
+}
+
+interface PreviewRequestBody {
+  wholeFolders?: string[];
+  members?: string[];
+  excluded?: string[];
+}
+
+const folders: Folder[] = [
+  { id: 'adv1', kind: 'Adventure', name: 'The Sapphire Heist', memberIds: ['npc1', 'npc2', 'pc1'] },
+  { id: 'roster1', kind: 'Roster', name: 'Main Roster', memberIds: ['pc2', 'pc3', 'npc3'] },
 ];
 
-const characters = [
+const characters: Character[] = [
   { id: 'pc1', kind: 'PC', name: 'Aria', defense: 18, tier: 2, threat: 0, updatedAt: '2025-09-20T12:00:00Z' },
   { id: 'npc1', kind: 'NPC', name: 'Victor Oldham', defense: 22, tier: 4, threat: 5, updatedAt: '2025-09-19T10:00:00Z' },
   { id: 'npc2', kind: 'NPC', name: 'Sir Reynard', defense: 19, tier: 3, threat: 3, updatedAt: '2025-09-19T11:00:00Z' },
@@ -24,25 +49,25 @@ function uniq<T>(arr: T[]): T[] {
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
-  const { wholeFolders = [], members = [], excluded = [] } = req.body;
+  const { wholeFolders = [], members = [], excluded = [] } = (req.body ?? {}) as PreviewRequestBody;
 
   // Gather all member IDs from selected folders
   const folderMembers = uniq(
-    wholeFolders.flatMap((fid: string) => {
-      const folder = folders.find((f: any) => f.id === fid);
+    wholeFolders.flatMap((fid) => {
+      const folder = folders.find((f) => f.id === fid);
       return folder ? folder.memberIds : [];
     })
   );
-  const picks = uniq([...folderMembers, ...members]).filter((id: string) => !excluded.includes(id));
+  const picks = uniq([...folderMembers, ...members]).filter((id) => !excluded.includes(id));
 
   // Fetch character records
-  const merged = characters.filter((c: any) => picks.includes(c.id));
+  const merged = characters.filter((character) => picks.includes(character.id));
 
   const headcount = merged.length;
-  const sumDefense = merged.reduce((a: number, b: any) => a + (b.defense ?? 0), 0);
+  const sumDefense = merged.reduce((sum, character) => sum + (character.defense ?? 0), 0);
   const avgDefense = headcount ? +(sumDefense / headcount).toFixed(1) : 0;
-  const avgTier = headcount ? +(merged.reduce((a: number, b: any) => a + b.tier, 0) / headcount).toFixed(1) : 0;
-  const sumThreat = merged.reduce((a: number, b: any) => a + (b.threat ?? 0), 0);
+  const avgTier = headcount ? +(merged.reduce((sum, character) => sum + character.tier, 0) / headcount).toFixed(1) : 0;
+  const sumThreat = merged.reduce((sum, character) => sum + (character.threat ?? 0), 0);
 
   res.status(200).json({ merged, dedupedCount: picks.length - merged.length, totals: { headcount, sumDefense, avgDefense, avgTier, sumThreat } });
 }

--- a/src/test/npc-parser.test.ts
+++ b/src/test/npc-parser.test.ts
@@ -3,7 +3,6 @@ import {
   collapseNPCEntry,
   findEquipment,
   formatPrimaryAttributes,
-  findMountOneLiner,
   extractDisposition,
   parseRaceClassLevel,
   validateStatBlock

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ["class"],

--- a/test-fix.js
+++ b/test-fix.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { processDumpEnhanced } = require('./dist/lib/npc-parser.js');
 const fs = require('fs');
 

--- a/test-your-input.js
+++ b/test-your-input.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 // Simple test script to verify the fix
 const input = "Men-at-Arms, Bowmen x10 (these 2ⁿᵈ level human fighters' vital stats are HP 14, AC 12, disposition neutral. PA physical. they wear leather armor and carry longbows, longswords, belt axes, and carry 2–12 gold in coin. they carry medium steel shields.)";
 


### PR DESCRIPTION
## Summary
- clean up unused imports and improve clipboard error handling in the main app and analyzer components
- remove unused parser exports, tighten typings, and add diagnostics in shared libraries to satisfy ESLint
- suppress lint noise in generated/config scripts and mock utilities used outside the build

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4395efc20832f8ca5dce79d87bf8e