### PR TITLE
Canonicalize individual NPC equipment and mount output

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -30,6 +30,7 @@ export interface AutoCorrectionOptions {
 }
 
 import { MAGIC_ITEM_MAPPINGS, addMagicItemMechanics } from './name-mappings';
+import type { ParentheticalData } from './enhanced-parser';
 import {
   splitTitleAndBody,
   extractParentheticalData,
@@ -42,7 +43,10 @@ import {
   buildCanonicalParenthetical,
   formatMountBlock as formatEnhancedMountBlock,
   normalizeAttributes,
-  MountBlock
+  MountBlock,
+  canonicalizeMountBlock,
+  lookupCanonicalMount,
+  buildMountBridgeSentence,
 } from './enhanced-parser';
 import {
   isBasicMonster,
@@ -762,7 +766,7 @@ function parseBlock(block: string): ParsedNPC {
       });
       const mountPossessive = toPossessiveSubject(mountSubject, false);
       mountBlock += `*(${mountPossessive} vital stats are ${mountStats.join(', ')}${attackText})*`;
-      fields['Mount'] = formatMountBlock(mountBlock);
+      fields['Mount'] = formatMountBlockFromString(mountBlock);
     }
   }
 
@@ -815,41 +819,72 @@ function parseBlock(block: string): ParsedNPC {
 
 // isBasicMonster and formatToMonsterNarrative moved to monster-formatter.ts
 
-function formatToEnhancedNarrative(parsed: ParsedNPC, originalBlock: string): string {
-  // Use enhanced parser formatting
-  const { title, parentheticals } = splitTitleAndBody(originalBlock);
-  const isUnit = isUnitHeading(title);
-
-  let name = parsed.name.trim();
-  if (!name.startsWith('**')) {
-    name = `**${name.replace(/\*\*/g, '').trim()}**`;
-  }
-
-  let result = name;
-  let mountBlock: MountBlock | undefined;
-
-  if (parentheticals.length > 0) {
-    // Extract mount first (Jeremy's mandate: separate mounts into dedicated blocks)
-    const { cleanedParenthetical, mountBlock: extractedMount } = extractMountFromParenthetical(parentheticals[0]);
-    mountBlock = extractedMount;
-
-    // Process the cleaned parenthetical (mount data removed)
-    const cleanedParentheticalData = extractParentheticalData(cleanedParenthetical, isUnit, title);
-    const canonicalParenthetical = buildCanonicalParenthetical(cleanedParentheticalData, isUnit, false, true, title);
-
-    // Only add parenthetical if it contains meaningful content (not just a period or empty)
-    if (canonicalParenthetical && canonicalParenthetical.trim().length > 1 && canonicalParenthetical.trim() !== '.') {
-      result = `${name} *(${canonicalParenthetical})*`;
+  function resolveMountPronoun(
+    data: ParentheticalData | undefined,
+    canonicalParenthetical: string,
+    isUnit: boolean,
+  ): 'He' | 'She' | 'They' {
+    const explicitPronounMatch = canonicalParenthetical.match(/\b(He|She|They)\s+(?:wear|carry|carries|can|wields|rides|ride)\b/);
+    if (explicitPronounMatch) {
+      return explicitPronounMatch[1] as 'He' | 'She' | 'They';
     }
+
+    const originalPronoun = data?.originalPronoun?.toLowerCase();
+    if (originalPronoun) {
+      if (['she', 'her'].includes(originalPronoun)) return 'She';
+      if (['they', 'their', 'these', 'those'].includes(originalPronoun)) return 'They';
+      if (['he', 'his', 'this'].includes(originalPronoun)) return 'He';
+    }
+
+    return isUnit ? 'They' : 'He';
   }
 
-  // Add separated mount block per Jeremy's editorial mandate
-  if (mountBlock) {
-    result += `\n\n${formatEnhancedMountBlock(mountBlock)}`;
-  }
+  function formatToEnhancedNarrative(parsed: ParsedNPC, originalBlock: string): string {
+    // Use enhanced parser formatting
+    const { title, parentheticals } = splitTitleAndBody(originalBlock);
+    const isUnit = isUnitHeading(title);
 
-  return result;
-}
+    let name = parsed.name.trim();
+    if (!name.startsWith('**')) {
+      name = `**${name.replace(/\*\*/g, '').trim()}**`;
+    }
+
+    let result = name;
+    let mountBlock: MountBlock | undefined;
+    let parentheticalData: ParentheticalData | undefined;
+    let canonicalParenthetical = '';
+
+    if (parentheticals.length > 0) {
+      // Extract mount first (Jeremy's mandate: separate mounts into dedicated blocks)
+      const { cleanedParenthetical, mountBlock: extractedMount } = extractMountFromParenthetical(parentheticals[0]);
+      mountBlock = extractedMount ? canonicalizeMountBlock(extractedMount) : undefined;
+
+      // Process the cleaned parenthetical (mount data removed)
+      parentheticalData = extractParentheticalData(cleanedParenthetical, isUnit, title);
+      canonicalParenthetical = buildCanonicalParenthetical(parentheticalData, isUnit, false, true, title);
+
+      // Only add parenthetical if it contains meaningful content (not just a period or empty)
+      if (canonicalParenthetical && canonicalParenthetical.trim().length > 1 && canonicalParenthetical.trim() !== '.') {
+        result = `${name} *(${canonicalParenthetical})*`;
+      }
+    }
+
+    // Add separated mount block per Jeremy's editorial mandate
+    if (mountBlock) {
+      const pronoun = resolveMountPronoun(parentheticalData, canonicalParenthetical, isUnit);
+      const mountSentence = buildMountBridgeSentence(mountBlock.name, pronoun);
+      if (!result.includes(mountSentence)) {
+        result += `\n\n${mountSentence}`;
+      }
+
+      const formattedMount = formatEnhancedMountBlock(mountBlock);
+      if (!result.includes(formattedMount)) {
+        result += `\n\n${formattedMount}`;
+      }
+    }
+
+    return result;
+  }
 
 function formatToNarrative(parsed: ParsedNPC): string {
   // Check if this is a Basic Monster
@@ -948,7 +983,7 @@ function formatToNarrative(parsed: ParsedNPC): string {
   let mountBlock = '';
   if (mount) {
     // Mount is already formatted as a complete canonical block from extraction
-    mountBlock = `\n\n${formatMountBlock(mount)}`;
+    mountBlock = `\n\n${formatMountBlockFromString(mount)}`;
   }
 
   const parenthetical = sentences.length > 0 ? ` *(${sentences.join(' ')})*` : '';
@@ -1227,7 +1262,7 @@ function buildVitalStatsSentence(options: VitalStatsOptions): string | null {
   return `${possessiveSubject} vital stats are ${fragments.join(', ')}.`;
 }
 
-function formatMountBlock(raw: string): string {
+function formatMountBlockFromString(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
     return '';
@@ -1241,6 +1276,11 @@ function formatMountBlock(raw: string): string {
   }
   if (/This creature['’]s vital stats are/i.test(pronounNormalized)) {
     return pronounNormalized;
+  }
+
+  const canonicalMount = lookupCanonicalMount(pronounNormalized);
+  if (canonicalMount) {
+    return formatEnhancedMountBlock(canonicalMount);
   }
 
   const nameWithoutTrailingPeriod = pronounNormalized.replace(/[.\s]+$/, '');
@@ -1274,65 +1314,68 @@ function dedupeFixes(fixes: CorrectionFix[]): CorrectionFix[] {
 // New functions required by tests and NotebookLM feedback
 
 export function collapseNPCEntry(input: string): string {
-  const processed = processDumpWithValidation(input);
-  if (processed.length === 0) return input;
-
-  const npc = processed[0];
-  const parsed = parseBlock(npc.original);
-
-  // Canonicalize and validate all required fields
-  let name = parsed.name;
-  if (!name.startsWith('**')) name = `**${name.replace(/\*/g, '')}**`;
-
-  // Mandatory fields: Race & Class, HP, AC, Disposition
-  const raceClass = parsed.fields['Race & Class'] || '[race/class missing]';
-  const { race, level, charClass } = parseRaceClassLevel(raceClass);
-  const disposition = parsed.fields['Disposition'] ? normalizeDisposition(parsed.fields['Disposition']) : '[disposition missing]';
-  const hp = parsed.fields['Hit Points (HP)'] || '[hp missing]';
-  const ac = parsed.fields['Armor Class (AC)'] || '[ac missing]';
-
-  // Linguistic flow: race before level/class
-  const raceClassPhrase = buildSubjectDescriptor({
-    isPlural: false,
-    race,
-    level,
-    charClass,
-    fallback: raceClass,
-  });
-  const possessivePhrase = toPossessiveSubject(raceClassPhrase, false);
-
-  // Primary attributes
-  const primaryAttrs = parsed.fields['Primary attributes']
-    ? formatPrimaryAttributes(parsed.fields['Primary attributes'])
-    : '[primary attributes missing]';
-
-  // Secondary skills
-  const secondarySkills = parsed.fields['Secondary Skills'];
-
-  // Equipment (canonicalize, apply wording rules, bonus placement, italics)
-  const equipment = parsed.fields['Equipment']
-    ? findEquipment(parsed.fields['Equipment'])
-    : '[equipment missing]';
-
-  // Mount: output as separate canonical block if present
-  let mountBlock = '';
-  if (parsed.fields['Mount']) {
-    mountBlock = `\n\n${formatMountBlock(parsed.fields['Mount'])}`;
+  const basePass = processDumpWithValidation(input, false, 'npc');
+  if (basePass.length === 0) {
+    return input.trim();
   }
 
-  // Build stat block content, enforcing punctuation and semicolons for equipment clauses
-  const sentences: string[] = [];
-  sentences.push(`${possessivePhrase} vital stats are HP ${hp}, AC ${ac}, disposition ${disposition}.`);
-  sentences.push(`Their primary attributes are ${primaryAttrs}.`);
-  if (secondarySkills) {
-    sentences.push(`Their secondary skill is ${secondarySkills}.`);
+  let intermediate = basePass[0].converted;
+  const mountBlockMatch = intermediate.match(/\r?\n\r?\n(\*\*[^*]+ \(mount\)\*\* \*\([^]*?\)\*)/);
+  const mountBlock = mountBlockMatch ? mountBlockMatch[1].trim() : '';
+
+  // Reorder race/class phrasing so that level precedes race ("This 5ᵗʰ level human fighter")
+  intermediate = intermediate.replace(
+    /(This|These)\s+([a-z-]+)\s+(\d+[^\s]*)\s+level\s+([a-z/-]+)([’']s)/gi,
+    (_, pronoun, race, level, charClass, possessive) =>
+      `${pronoun} ${level} level ${race} ${charClass}${possessive}`,
+  );
+
+  // Encourage enhanced parser spell extraction by standardizing the lead-in phrase
+  intermediate = intermediate.replace(
+    /(They|He|She) can cast ([^.]+)\./i,
+    (_, pronoun, list) => `${pronoun} can cast the following number of spells per day: ${list}.`,
+  );
+
+  const enhancedPass = processDumpWithValidation(intermediate, true, 'npc');
+  if (enhancedPass.length === 0) {
+    return intermediate.trim();
   }
-  sentences.push(`They carry ${equipment}.`);
 
-  // Markdown: wrap parenthetical in single outer italics, no nested asterisks
-  const parenthetical = `*(${sentences.join(' ')})*`;
+  let final = enhancedPass[0].converted.trim();
+  const nameMatch = final.match(/^(\*\*[^*]+?\*\*)(.*)$/s);
+  if (nameMatch) {
+    const [, name, rest] = nameMatch;
+    const normalizedRest = rest.replace(/^\s*\*+/, ' *');
+    const normalizedName = name.replace(/\s+\*\*$/, '**');
+    final = `${normalizedName}${normalizedRest}`;
+  }
+  final = final.replace(/ \*\s*\*\(/g, ' *(');
+  final = final.replace(/\*\(([^)]*)\)\*/g, (_, inner) => `*(${inner.replace(/\*\*/g, '*')})*`);
 
-  return `${name} ${parenthetical}${mountBlock}`;
+  if (mountBlock) {
+    const mountNameMatch = mountBlock.match(/\*\*([^*]+?) \(mount\)\*\*/i);
+    const mountName = mountNameMatch ? mountNameMatch[1] : '';
+    const canonicalMount = mountName ? lookupCanonicalMount(mountName) : undefined;
+    const resolvedMountName = canonicalMount ? canonicalMount.name : mountName;
+    const canonicalMountBlock = canonicalMount
+      ? formatEnhancedMountBlock(canonicalMount)
+      : mountBlock;
+
+    const pronounMatch = final.match(/\*\([^)]*\.\s+(He|She|They)\b/);
+    const pronoun = (pronounMatch ? pronounMatch[1] : 'He') as 'He' | 'She' | 'They';
+
+    if (resolvedMountName) {
+      const mountSentence = buildMountBridgeSentence(resolvedMountName, pronoun);
+      if (!final.includes(mountSentence)) {
+        final = `${final}\n\n${mountSentence}`;
+      }
+    }
+
+    if (!final.includes(canonicalMountBlock)) {
+      final = `${final}\n\n${canonicalMountBlock}`;
+    }
+  }
+  return final;
 }
 
 export function findEquipment(equipment: string): string {
@@ -1424,7 +1467,10 @@ export function formatPrimaryAttributes(attributes: string): string {
 }
 
 export function findMountOneLiner(mount: string): string {
-  return `rides a ${mount}.`;
+  const normalized = mount.trim();
+  const article = /^[aeiou]/i.test(normalized) ? 'an' : 'a';
+  const mountName = normalized.replace(/war\s+horse/gi, 'warhorse');
+  return `rides ${article} ${mountName} in battle.`;
 }
 
 export function extractDisposition(text: string): string {

--- a/src/test/attribute-handling.test.ts
+++ b/src/test/attribute-handling.test.ts
@@ -54,7 +54,7 @@ describe('Attribute Handling Rules', () => {
 
       expect(result.type).toBe('list');
       // All fighter primes: strength, dexterity, constitution
-      expect(result.value).toBe('strength, dexterity, constitution');
+      expect(result.value).toBe('strength, dexterity, and constitution');
     });
 
     it('should list cleric prime (wisdom) when score provided', () => {
@@ -76,7 +76,7 @@ describe('Attribute Handling Rules', () => {
 
       expect(result.type).toBe('list');
       // Wizard prime is intelligence, charisma 14 also has modifier
-      expect(result.value).toBe('intelligence, charisma');
+      expect(result.value).toBe('intelligence and charisma');
     });
 
     it('should list rogue prime (dexterity) when provided', () => {
@@ -98,7 +98,7 @@ describe('Attribute Handling Rules', () => {
 
       expect(result.type).toBe('list');
       // Ranger primes: strength, dexterity, wisdom (all provided with modifiers)
-      expect(result.value).toBe('strength, dexterity, wisdom');
+      expect(result.value).toBe('strength, dexterity, and wisdom');
     });
   });
 
@@ -146,7 +146,7 @@ describe('Attribute Handling Rules', () => {
       expect(result.type).toBe('list');
       // Fighter primes: str, dex, con (all listed)
       // Plus int 8 and cha 14 have modifiers
-      expect(result.value).toBe('strength, dexterity, constitution, intelligence, charisma');
+      expect(result.value).toBe('strength, dexterity, constitution, intelligence, and charisma');
     });
 
     it('should handle paladin with multiple primes and high strength', () => {
@@ -157,7 +157,7 @@ describe('Attribute Handling Rules', () => {
 
       expect(result.type).toBe('list');
       // Paladin primes: wisdom, charisma; also strength 14 has a modifier
-      expect(result.value).toBe('strength, wisdom, charisma');
+      expect(result.value).toBe('strength, wisdom, and charisma');
     });
   });
 });

--- a/src/test/enhanced-parser.test.ts
+++ b/src/test/enhanced-parser.test.ts
@@ -108,7 +108,7 @@ describe('Enhanced Parser Functions', () => {
       });
       expect(result.type).toBe('list');
       // Fighters have strength, dexterity, constitution as primes
-      expect(result.value).toBe('strength, dexterity, constitution');
+      expect(result.value).toBe('strength, dexterity, and constitution');
     });
 
     it('should always include fighter primes for 1st level fighters', () => {
@@ -117,7 +117,7 @@ describe('Enhanced Parser Functions', () => {
         levelText: '1'
       });
       expect(result.type).toBe('list');
-      expect(result.value).toBe('strength, dexterity, constitution');
+      expect(result.value).toBe('strength, dexterity, and constitution');
     });
 
     it('should return prime type for creatures without class levels', () => {
@@ -182,7 +182,7 @@ describe('Enhanced Parser Functions', () => {
       const result = extractMountFromParenthetical(input);
 
       expect(result.mountBlock).toBeDefined();
-      expect(result.mountBlock?.name).toBe('warhorse');
+      expect(result.mountBlock?.name).toBe('heavy war horse');
       expect(result.mountBlock?.hp).toBe('35');
       expect(result.mountBlock?.ac).toBe('19');
       expect(result.cleanedParenthetical).not.toContain('war horse');
@@ -215,8 +215,8 @@ describe('Enhanced Parser Functions', () => {
 
       expect(result).toContain("HP 24, AC 16, disposition neutral");
       // Fighters list all primes: strength, dexterity, constitution
-      expect(result).toContain("His primary attributes are strength, dexterity, constitution");
-      expect(result).toContain('He wears');
+      expect(result).toContain('His primary attributes are strength, dexterity, and constitution');
+      expect(result).toContain('He carries banded mail, a medium steel shield, a longsword, and a dagger');
     });
 
     it('should build canonical format for unit', () => {
@@ -273,7 +273,7 @@ describe('Enhanced Parser Functions', () => {
       const result = buildCanonicalParenthetical(data, false, false, false);
 
       // Should have exactly one carry sentence that includes both jewelry and coins
-      expect(result).toContain('He carries 25 in coin and fifty in jewelry');
+      expect(result).toContain('He carries leather armor, 25 in coin, and fifty in jewelry.');
 
       // Should only have one instance of "carries" (merged into single sentence)
       const carriesCount = (result.match(/\bcarries\b/g) || []).length;

--- a/src/test/npc-parser.test.ts
+++ b/src/test/npc-parser.test.ts
@@ -25,7 +25,7 @@ Spells: 0–6, 1st–6`
       
       // Should have the pattern **Name[, Title]** *(italic content)*
       expect(result).toMatch(/\*\*[^*]+\*\* \*\(.*\)\*/)
-      expect(result).toContain('*(This human 16ᵗʰ level cleric')
+      expect(result).toContain('*(This 16ᵗʰ level human cleric')
       expect(result).toContain('disposition law/good.')
     })
   })
@@ -154,7 +154,8 @@ Mount: heavy war horse`
 
       const result = collapseNPCEntry(input)
 
-      expect(result).toContain('**Heavy War Horse (mount)** *(This creature’s vital stats are unavailable.)*')
+      expect(result).toContain('He rides a heavy warhorse in battle.')
+      expect(result).toContain('**Heavy War Horse (mount)** *(This creature’s vital stats are HD 4d10, HP 35, AC 19, disposition neutral. It receives two hoof attacks for 1–4 damage or one overbearing attack. It wears chain mail barding.)*')
     })
   })
 
@@ -182,7 +183,7 @@ Armor Class (AC): 17`;
 
       const parentheticalMatch = result.match(/\*\((.+?)\)\*/);
       const parenthetical = parentheticalMatch ? parentheticalMatch[1] : '';
-      expect(parenthetical).toMatch(/This human 5ᵗʰ level fighter/i);
+      expect(parenthetical).toMatch(/This 5ᵗʰ level human fighter/i);
     });
   });
 
@@ -241,15 +242,39 @@ Mount: heavy war horse`
       // Check all major formatting requirements
       expect(result).toMatch(/\*\*.*\*\* \*\(.*\)\*/) // Italicized stat block
       expect(result).toContain('disposition law/good.') // Complete sentence
-      expect(result).toContain('strength, wisdom, and charisma') // Lowercase PHB order
-      expect(result).toContain('*pectoral of armor +3 (AC +1 to +3)*') // PHB rename + italics
-	expect(result).toContain('medium steel shield') // Shield normalization (defaults)
-      expect(result).toContain('*staff of striking (see Appendix: Magic Items)*') // Magic item italics
+      expect(result).toContain('strength, wisdom, and charisma') // Lowercase PHB order with Oxford comma
+      expect(result).toContain('He carries a pectoral of armor +3, full plate mail, a medium steel shield, a staff of striking, and a mace.')
+      expect(result).toContain('He rides a heavy warhorse in battle.')
       const mainBlockMatch = result.match(/\*\((.+?)\)\*/s)
       const mainBlock = mainBlockMatch ? mainBlockMatch[1] : ''
       expect(mainBlock).not.toMatch(/\*\*/)
       // Canonical mount block with neutral pronoun
-      expect(result).toContain('**Heavy War Horse (mount)** *(This creature’s vital stats are unavailable.)*')
+      expect(result).toContain('**Heavy War Horse (mount)** *(This creature’s vital stats are HD 4d10, HP 35, AC 19, disposition neutral. It receives two hoof attacks for 1–4 damage or one overbearing attack. It wears chain mail barding.)*')
+    })
+  })
+
+  describe('Default example regression', () => {
+    it('should match the canonical Victor Oldham entry', () => {
+      const input = `**The Right Honorable President Counselor of Yggsburgh, His Supernal Devotion Victor Oldham, High Priest of the Grand Temple**
+
+Disposition: law/good
+Race & Class: human, 16th level cleric
+Hit Points (HP): 59
+Armor Class (AC): 13/22
+Primary attributes: strength, wisdom, charisma
+Equipment: pectoral of armor +3, full plate mail, large steel shield, staff of striking, mace
+Spells: 0–6, 1st–6, 2nd–5, 3rd–5, 4th–4, 5th–4, 6th–3, 7th–3, 8th–2
+Mount: heavy war horse`
+
+      const expected = `**The Right Honorable President Counselor of Yggsburgh, His Supernal Devotion Victor Oldham, High Priest of the Grand Temple** *(This 16ᵗʰ level human cleric’s vital stats are HP 59, AC 13/22, disposition law/good. His primary attributes are strength, wisdom, and charisma. He carries a pectoral of armor +3, full plate mail, a large steel shield, a staff of striking, and a mace. He can cast the following number of cleric spells per day: 0–6, 1ˢᵗ–6, 2ⁿᵈ–5, 3ʳᵈ–5, 4ᵗʰ–4, 5ᵗʰ–4, 6ᵗʰ–3, 7ᵗʰ–3, 8ᵗʰ–2.)*
+
+He rides a heavy warhorse in battle.
+
+**Heavy War Horse (mount)** *(This creature’s vital stats are HD 4d10, HP 35, AC 19, disposition neutral. It receives two hoof attacks for 1–4 damage or one overbearing attack. It wears chain mail barding.)*`
+
+      const result = collapseNPCEntry(input)
+
+      expect(result).toBe(expected)
     })
   })
 
@@ -269,7 +294,8 @@ Mount: heavy war horse`
       expect(result).toContain('mace')
 
       // Mount from prose creates canonical block
-      expect(result).toContain('**Heavy War Horse (mount)** *(This creature’s vital stats are unavailable.)*')
+      expect(result).toContain('He rides a heavy warhorse in battle.')
+      expect(result).toContain('**Heavy War Horse (mount)** *(This creature’s vital stats are HD 4d10, HP 35, AC 19, disposition neutral. It receives two hoof attacks for 1–4 damage or one overbearing attack. It wears chain mail barding.)*')
     })
   })
 })

--- a/src/test/unit-detection.test.ts
+++ b/src/test/unit-detection.test.ts
@@ -92,9 +92,7 @@ describe('Unit Detection', () => {
     expect(converted).not.toContain('Their');
 
     // Should use singular verbs
-    expect(converted).toContain('wears');
-    expect(converted).toContain('carries');
-    expect(converted).not.toContain(/\bwear\b/);
-    expect(converted).not.toContain(/\bcarry\b/);
+    expect(converted).toContain('He carries');
+    expect(converted).not.toContain('He wears');
   });
 });

--- a/test-templates.test.ts
+++ b/test-templates.test.ts
@@ -50,7 +50,7 @@ describe('Template Format Verification', () => {
     console.log('');
 
     expect(result).toContain('His primary attributes are');
-    expect(result).toContain('He wears');
+    expect(result).toContain('He carries');
   });
 
   it('Template 3: Unit of Classed NPCs', () => {


### PR DESCRIPTION
## Summary
- Update the enhanced parser to emit Oxford-comma attribute lists, treat classed individuals’ gear as a single carries sentence, and render canonical mount blocks with known warhorse statistics
- Reattach canonical mount text and bridging sentences in collapseNPCEntry so default NPC examples and prose inputs match the required Council of Eight format
- Refresh parser, attribute, template, and unit tests to cover the new canonical equipment phrasing and heavy warhorse block

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e443fc39f4832f87313893fc729aa3