### PR TITLE
Fix mount pronoun fallback for plural NPC units

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -1362,8 +1362,22 @@ export function collapseNPCEntry(input: string): string {
       ? formatEnhancedMountBlock(canonicalMount)
       : mountBlock;
 
-    const pronounMatch = final.match(/\*\([^)]*\.\s+(He|She|They)\b/);
-    const pronoun = (pronounMatch ? pronounMatch[1] : 'He') as 'He' | 'She' | 'They';
+    const pronounToken =
+      final.match(/\b(He|She|They)\b/)?.[1] ?? final.match(/\b(His|Her|Their)\b/)?.[1];
+    const unitNameMatch = final.match(/\*\*[^*]+?\s+x\d+\*\*/);
+    const defaultPronoun: 'He' | 'She' | 'They' = unitNameMatch ? 'They' : 'He';
+    const pronounMap: Record<'He' | 'She' | 'They' | 'His' | 'Her' | 'Their', 'He' | 'She' | 'They'> = {
+      He: 'He',
+      She: 'She',
+      They: 'They',
+      His: 'He',
+      Her: 'She',
+      Their: 'They',
+    };
+    const pronoun: 'He' | 'She' | 'They' =
+      (pronounToken
+        ? pronounMap[pronounToken as keyof typeof pronounMap]
+        : defaultPronoun) ?? defaultPronoun;
 
     if (resolvedMountName) {
       const mountSentence = buildMountBridgeSentence(resolvedMountName, pronoun);
@@ -1375,6 +1389,7 @@ export function collapseNPCEntry(input: string): string {
     if (!final.includes(canonicalMountBlock)) {
       final = `${final}\n\n${canonicalMountBlock}`;
     }
+  }
 
   if (mountBlock && !final.includes(mountBlock)) {
     final = `${final}\n\n${mountBlock}`;


### PR DESCRIPTION
## Summary
- update the mount bridge pronoun detection to include possessive pronouns when scanning the canonicalized NPC text
- fall back to a plural pronoun when the collapsed entry name already indicates a unit roster quantity

## Testing
- npm test *(fails: Council of Eight integration test expects the legacy "strength, wisdom, charisma" substring)*

------
https://chatgpt.com/codex/tasks/task_e_68e5628c58b4832fa399749c17368eed