### PR TITLE
fix(parser): Add fallback for enhanced parser

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -858,6 +858,14 @@ function parseBlock(block: string): ParsedNPC {
   }
 
   function formatToEnhancedNarrative(parsed: ParsedNPC, originalBlock: string): string {
+    // If the enhanced parser returns no fields, it's likely because the stat block
+    // is not in the expected parenthetical format. In this case, we fall back to the
+    // standard parser and formatter to handle line-by-line formats gracefully.
+    if (Object.keys(parsed.fields).length === 0 && !isUnitHeading(parsed.name)) {
+      const fallbackParsed = parseBlock(originalBlock);
+      return formatToNarrative(fallbackParsed);
+    }
+
     // Use enhanced parser formatting
     const { title, parentheticals } = splitTitleAndBody(originalBlock);
     const isUnit = isUnitHeading(title);


### PR DESCRIPTION
The enhanced parser was failing to parse line-by-line stat blocks, resulting in an empty output. This was most noticeable in the default example on the home page.

This commit adds a fallback mechanism to `formatToEnhancedNarrative`. If the enhanced parser does not extract any fields from a stat block, it will now fall back to the standard `parseBlock` and `formatToNarrative` functions. This ensures that line-by-line stat blocks are parsed correctly, even when the "Enhanced" formatter is selected in the UI, resolving the issue of stripped information.