### PR TITLE
fix: Remove unused imports from npc-parser.ts

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -29,7 +29,6 @@ export interface AutoCorrectionOptions {
   enableDictionarySuggestions?: boolean;
 }
 
-import { MAGIC_ITEM_MAPPINGS, addMagicItemMechanics } from './name-mappings';
 import type { ParentheticalData } from './enhanced-parser';
 import {
   splitTitleAndBody,


### PR DESCRIPTION
Removes the `MAGIC_ITEM_MAPPINGS` and `addMagicItemMechanics` imports from `src/lib/npc-parser.ts` as they were unused and causing ESLint warnings.