### PR TITLE
feat: Default to human for NPCs with unspecified race

### DIFF
--- a/src/lib/stat-block-helpers.ts
+++ b/src/lib/stat-block-helpers.ts
@@ -55,7 +55,12 @@ export function buildSubjectDescriptor(options: SubjectOptions): string {
   }
 
   if (!descriptor) {
-    descriptor = options.isPlural ? 'creatures' : options.charClass ? options.charClass : 'character';
+    if (options.isPlural) {
+      descriptor = 'creatures';
+    } else {
+      // Default to "human" if no race is specified for a single character.
+      descriptor = options.charClass ? options.charClass : 'human';
+    }
     descriptor = descriptor.toLowerCase();
   }
 


### PR DESCRIPTION
Modified the `buildSubjectDescriptor` function to default to "human" for singular NPCs where the race is not explicitly provided. This addresses an issue where such characters were being described with the generic term "creature", improving the accuracy and readability of the generated descriptions.