### PR TITLE
Fix build failure by correcting syntax error in npc-parser.ts

### DIFF
--- a/src/lib/npc-parser.ts
+++ b/src/lib/npc-parser.ts
@@ -1545,9 +1545,7 @@ export function collapseNPCEntry(input: string): string {
 
   if (mountBlock && !final.includes(mountBlock)) {
     final = `${final}\n\n${mountBlock}`;
-
-
-
+  }
 
   return final;
 }


### PR DESCRIPTION
The build was failing with the error "x 'import', and 'export' cannot be used outside of module code". This was caused by a syntax error in the `collapseNPCEntry` function in `src/lib/npc-parser.ts`.

A misplaced closing brace and `return` statement caused the function to be malformed, which in turn caused the build system to fail to parse the file as a module.

This commit moves the closing brace and `return` statement to their correct positions, resolving the syntax error and the build failure. The original logic of the function is preserved.