### PR TITLE
Fix lint issues blocking Next build

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />

--- a/scripts/extract_parentheticals.js
+++ b/scripts/extract_parentheticals.js
@@ -58,7 +58,7 @@ function deriveInlineLabel(prefix) {
     return colonMatch[1].trim();
   }
 
-  const fragments = text.split(/[\.\u2014–-]/).map(s => s.trim()).filter(Boolean);
+  const fragments = text.split(/[.\u2014–-]/).map(s => s.trim()).filter(Boolean);
   if (fragments.length > 0) {
     return fragments[fragments.length - 1];
   }

--- a/src/components/FullDocumentPipeline.stories.tsx
+++ b/src/components/FullDocumentPipeline.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { FullDocumentPipeline } from './FullDocumentPipeline';
 import { mouthsOfMadnessAnalysis } from './mocks/mouths-of-madness.mock';

--- a/src/components/FullDocumentPipeline.tsx
+++ b/src/components/FullDocumentPipeline.tsx
@@ -649,19 +649,21 @@ export function FullDocumentPipeline({ initialAnalysis = null, isProcessing: isP
 }
 
 // Storybook/mock-safe helpers: some mocks convert Map -> plain object during JSON.stringify.
-function getCreatureTypeEntries(mapLike: any): Array<[string, number]> {
+type CreatureTypeCounts = Map<string, number> | Record<string, number> | undefined | null;
+
+function getCreatureTypeEntries(mapLike: CreatureTypeCounts): Array<[string, number]> {
   if (!mapLike) return [];
-  if (typeof mapLike.entries === 'function') {
-    return Array.from(mapLike.entries());
+  if (typeof (mapLike as Map<string, number>).entries === 'function') {
+    return Array.from((mapLike as Map<string, number>).entries());
   }
   // assume plain object
-  return Object.entries(mapLike);
+  return Object.entries(mapLike as Record<string, number>);
 }
 
-function getCreatureTypeCount(mapLike: any): number {
+function getCreatureTypeCount(mapLike: CreatureTypeCounts): number {
   if (!mapLike) return 0;
-  if (typeof mapLike.size === 'number') return mapLike.size;
-  if (typeof mapLike.entries === 'function') return Array.from(mapLike.entries()).length;
+  if (typeof (mapLike as Map<string, number>).size === 'number') return (mapLike as Map<string, number>).size;
+  if (typeof (mapLike as Map<string, number>).entries === 'function') return Array.from((mapLike as Map<string, number>).entries()).length;
   // plain object
-  return Object.keys(mapLike).length;
+  return Object.keys(mapLike as Record<string, number>).length;
 }

--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -137,8 +137,8 @@ export interface ParsedTitleAndBody {
   parentheticals: string[];
 }
 
-import { addMagicItemMechanics, applyNameMappings, MAGIC_ITEM_MAPPINGS, canonicalizeMagicItemName } from './name-mappings';
-import { estimateHpFromHd, isRankedNamedEntity, formatHdAsLevel } from './stat-block-helpers';
+import { addMagicItemMechanics, applyNameMappings, canonicalizeMagicItemName } from './name-mappings';
+import { isRankedNamedEntity, formatHdAsLevel } from './stat-block-helpers';
 import type { FormattingRules } from './classification-rules';
 import { classifyEntityV3, type SignalExtractionContext } from './classification-rules';
 
@@ -1093,7 +1093,7 @@ export function repositionMagicItemBonuses(equipment: string): string {
 }
 
 export function deduplicateEquipment(equipment: string): string {
-  const items = equipment.split(/,\s*/).map(item => item.trim().replace(/[\.]+$/g, ''));
+  const items = equipment.split(/,\s*/).map(item => item.trim().replace(/[.]+$/g, ''));
   const unique = [...new Set(items)];
   return unique.join(', ');
 }
@@ -1564,8 +1564,6 @@ export function buildCanonicalParenthetical(
       descriptorData = { ...descriptorData, raceClass: raceClassText };
     }
 
-    const descriptor = buildDescriptorFromData(descriptorData, isUnit, title);
-    const possessive = formatPossessiveDescriptor(descriptor, isUnit);
     // Per Canonicalizer mandate: omit "vital stats are" and begin directly with stat content
     parts.push(`${vitalParts.join(', ')}`);
   }
@@ -1606,7 +1604,7 @@ export function buildCanonicalParenthetical(
   if (normalizedAttrs && normalizedAttrs.value) {
     if (normalizedAttrs.type === 'list') {
       // Format A: Long-form with singular possessive
-      let possessive = fallbackBase;
+      const possessive = fallbackBase;
       parts.push(`${possessive} primary attributes are ${normalizedAttrs.value}`);
     } else if (normalizedAttrs.type === 'prime') {
       // Format B/C: Shorthand
@@ -2037,7 +2035,7 @@ export function formatMountBlock(mountBlock: MountBlock): string {
 }
 
 export function findEquipment(equipment: string): string {
-  let processed = applyNameMappings(equipment);
+  const processed = applyNameMappings(equipment);
 
   // Shield normalization: split by comma, process each part individually
   const parts = processed.split(',').map(part => part.trim());

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest/config" />
-/// <reference types="vitest" />
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary
- remove unused imports and convert helper types to avoid eslint errors
- resolve no-useless-escape warnings and enforce lint exclusions on generated files
- clean up Storybook story imports and adjust regex handling

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cac640cdc832fb900f6bd0ba18a0f)