### PR TITLE
Fix lint errors blocking build

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist', '.next', 'node_modules', '**/*.cjs'] },
+  { ignores: ['dist', '.next', 'node_modules', '**/*.cjs', 'next-env.d.ts', 'vite.config.ts'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx,js,jsx}'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ import tseslint from 'typescript-eslint';
 import nextPlugin from '@next/eslint-plugin-next';
 
 export default tseslint.config(
-  { ignores: ['dist', '.next', 'node_modules', 'next-env.d.ts', 'tailwind.config.js', 'test-*.js', '*.config.js'] },
+  { ignores: ['dist', '.next', 'node_modules', 'next-env.d.ts', 'tailwind.config.js', 'test-*.js', '*.config.js', 'vite.config.ts'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx,js,jsx}'],

--- a/scripts/extract_parentheticals.js
+++ b/scripts/extract_parentheticals.js
@@ -58,7 +58,7 @@ function deriveInlineLabel(prefix) {
     return colonMatch[1].trim();
   }
 
-  const fragments = text.split(/[\.\u2014–-]/).map(s => s.trim()).filter(Boolean);
+  const fragments = text.split(/[.\u2014–-]/).map(s => s.trim()).filter(Boolean);
   if (fragments.length > 0) {
     return fragments[fragments.length - 1];
   }

--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -137,8 +137,8 @@ export interface ParsedTitleAndBody {
   parentheticals: string[];
 }
 
-import { addMagicItemMechanics, applyNameMappings, MAGIC_ITEM_MAPPINGS, canonicalizeMagicItemName } from './name-mappings';
-import { estimateHpFromHd, isRankedNamedEntity, formatHdAsLevel } from './stat-block-helpers';
+import { addMagicItemMechanics, applyNameMappings, canonicalizeMagicItemName } from './name-mappings';
+import { isRankedNamedEntity, formatHdAsLevel } from './stat-block-helpers';
 import type { FormattingRules } from './classification-rules';
 import { classifyEntityV3, type SignalExtractionContext } from './classification-rules';
 
@@ -1093,7 +1093,7 @@ export function repositionMagicItemBonuses(equipment: string): string {
 }
 
 export function deduplicateEquipment(equipment: string): string {
-  const items = equipment.split(/,\s*/).map(item => item.trim().replace(/[\.]+$/g, ''));
+  const items = equipment.split(/,\s*/).map(item => item.trim().replace(/[.]+$/g, ''));
   const unique = [...new Set(items)];
   return unique.join(', ');
 }
@@ -1565,7 +1565,6 @@ export function buildCanonicalParenthetical(
     }
 
     const descriptor = buildDescriptorFromData(descriptorData, isUnit, title);
-    const possessive = formatPossessiveDescriptor(descriptor, isUnit);
     // Per Canonicalizer mandate: omit "vital stats are" and begin directly with stat content
     parts.push(`${vitalParts.join(', ')}`);
   }
@@ -1606,7 +1605,7 @@ export function buildCanonicalParenthetical(
   if (normalizedAttrs && normalizedAttrs.value) {
     if (normalizedAttrs.type === 'list') {
       // Format A: Long-form with singular possessive
-      let possessive = fallbackBase;
+      const possessive = fallbackBase;
       parts.push(`${possessive} primary attributes are ${normalizedAttrs.value}`);
     } else if (normalizedAttrs.type === 'prime') {
       // Format B/C: Shorthand
@@ -2037,7 +2036,7 @@ export function formatMountBlock(mountBlock: MountBlock): string {
 }
 
 export function findEquipment(equipment: string): string {
-  let processed = applyNameMappings(equipment);
+  const processed = applyNameMappings(equipment);
 
   // Shield normalization: split by comma, process each part individually
   const parts = processed.split(',').map(part => part.trim());

--- a/src/lib/stat-block-helpers.ts
+++ b/src/lib/stat-block-helpers.ts
@@ -18,7 +18,7 @@ export function normalizeDisposition(value: string): string {
   };
 
   // Normalize whitespace/punctuation and lowercase for lookup
-  const trimmed = value.trim().toLowerCase().replace(/[\-\/\\]/g, ' ').replace(/\.+$/, '');
+  const trimmed = value.trim().toLowerCase().replace(/[-/\\]/g, ' ').replace(/\.+$/, '');
 
   // Support common one- or two-letter abbreviations (LG, CN, etc.)
   const abbr = trimmed.replace(/[^a-z]/g, '');


### PR DESCRIPTION
## Summary
- ignore generated files in ESLint config to avoid false positives during build
- clean up regex escapes and unused imports causing lint failures in parsing utilities
- simplify parenthetical extraction regex to remove unnecessary escapes

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694204fc747c832f92c6d631607cf83a)