### PR TITLE
Fix canonicalize script imports for build

### DIFF
--- a/scripts/canonicalize_candidates.ts
+++ b/scripts/canonicalize_candidates.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env tsx
 import fs from 'fs';
 import path from 'path';
-import { extractParentheticalData, buildCanonicalParenthetical, isUnitHeading, expandShorthandForClassed, normalizePrimaryAttributesForMonsters, canonicalizeShields, repositionMagicItemBonuses, normalizeEquipmentVerbs, deduplicateEquipment } from '../src/lib/enhanced-parser.ts';
-import { classifyCreature, classifyEntityV3, extractPreCheckData, getFormattingRules } from '../src/lib/classification-rules.ts';
-import type { CanonicalData } from '../src/lib/canonical-data-mapper.ts';
+import { extractParentheticalData, buildCanonicalParenthetical, isUnitHeading, expandShorthandForClassed, normalizePrimaryAttributesForMonsters, canonicalizeShields, repositionMagicItemBonuses, normalizeEquipmentVerbs, deduplicateEquipment } from '../src/lib/enhanced-parser';
+import { classifyCreature, classifyEntityV3, extractPreCheckData, getFormattingRules } from '../src/lib/classification-rules';
+import type { CanonicalData } from '../src/lib/canonical-data-mapper';
 
 const DATA_SCOPE = process.env.DATA_SCOPE || 'mouths-of-madness';
 const DATA_DIR = path.join(process.cwd(), 'data', DATA_SCOPE);


### PR DESCRIPTION
### Motivation
- The Next.js build failed with: "An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.".
- This error originated from `scripts/canonicalize_candidates.ts` importing internal modules with explicit `.ts` extensions.
- The change aims to make the script compatible with the TypeScript/Next.js resolver without changing tsconfig flags.

### Description
- Removed `.ts` extensions from internal imports in `scripts/canonicalize_candidates.ts` for `enhanced-parser`, `classification-rules`, and `canonical-data-mapper`.
- Kept all imported symbols and types unchanged to preserve runtime behavior.
- Committed the change as a single-file update to `scripts/canonicalize_candidates.ts`.

### Testing
- No automated tests were run as part of this change.
- The change is expected to resolve the Next.js build import error and allow `npm run build` to proceed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b2674e6c832f8e0d2a24fc30ebef)