### PR TITLE
Fix canonicalize script imports for Next build

### DIFF
--- a/scripts/canonicalize_candidates.ts
+++ b/scripts/canonicalize_candidates.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env tsx
 import fs from 'fs';
 import path from 'path';
-import { extractParentheticalData, buildCanonicalParenthetical, isUnitHeading, expandShorthandForClassed, normalizePrimaryAttributesForMonsters, canonicalizeShields, repositionMagicItemBonuses, normalizeEquipmentVerbs, deduplicateEquipment } from '../src/lib/enhanced-parser.ts';
-import { classifyCreature, classifyEntityV3, extractPreCheckData, getFormattingRules } from '../src/lib/classification-rules.ts';
-import type { CanonicalData } from '../src/lib/canonical-data-mapper.ts';
+import { extractParentheticalData, buildCanonicalParenthetical, isUnitHeading, expandShorthandForClassed, normalizePrimaryAttributesForMonsters, canonicalizeShields, repositionMagicItemBonuses, normalizeEquipmentVerbs, deduplicateEquipment } from '../src/lib/enhanced-parser';
+import { classifyCreature, classifyEntityV3, extractPreCheckData, getFormattingRules } from '../src/lib/classification-rules';
+import type { CanonicalData } from '../src/lib/canonical-data-mapper';
 
 const DATA_SCOPE = process.env.DATA_SCOPE || 'mouths-of-madness';
 const DATA_DIR = path.join(process.cwd(), 'data', DATA_SCOPE);


### PR DESCRIPTION
### Motivation
- Fix a Next.js build failure caused by TypeScript import paths ending with `.ts` which are disallowed unless `allowImportingTsExtensions` is enabled.
- Allow the `scripts/canonicalize_candidates.ts` script to import project modules during `next build` without changing TS compiler settings.

### Description
- Removed `.ts` extensions from imports in `scripts/canonicalize_candidates.ts` for `../src/lib/enhanced-parser`, `../src/lib/classification-rules`, and `../src/lib/canonical-data-mapper`.
- No other code or runtime logic was modified.

### Testing
- No automated tests were executed for this change.
- Please run the CI `npm run build` (or `next build`) to confirm the previous TypeScript import error is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b47384d8832fa6b5e3ed2ee8db84)