### PR TITLE
Fix XP flagging type error in canonicalize_candidates.ts

### DIFF
--- a/scripts/canonicalize_candidates.ts
+++ b/scripts/canonicalize_candidates.ts
@@ -187,7 +187,7 @@ function analyzeAndCanonicalize() {
       if (!data.hp && data.ac) flags.push('missing HP');
       if (!data.ac && data.hp) flags.push('missing AC');
       if (!data.raceClass) flags.push('missing raceClass');
-      if (!data.xp && !/XP[:\s]/i.test(item.parenthetical || '')) flags.push('missing XP');
+      if (!/XP[:\s]/i.test(item.parenthetical || '')) flags.push('missing XP');
 
       if (flags.length > 0) {
         report.flagged.push({ title: title || item.snippet || '', start: item.start, flags });


### PR DESCRIPTION
### Motivation
- The production build failed with a TypeScript error caused by referencing a non-existent `xp` property on `ParentheticalData`.
- Ensure the canonicalization script can flag missing XP without accessing undefined fields and stopping the build.

### Description
- Remove the `data.xp` property check and rely solely on the `item.parenthetical` regex `/XP[:\s]/i` when flagging missing XP.
- Update `scripts/canonicalize_candidates.ts` to avoid the TypeScript type error and keep XP detection based on the parenthetical text.
- Commit includes the single-line change to the missing-XP flag logic.

### Testing
- No automated tests were run against the modified code.
- Prior to this change, `npm run build` (Next.js build) failed with the TypeScript error `Property 'xp' does not exist on type 'ParentheticalData'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b5d9b2e0832fb7d49cc5e1125298)