### PR TITLE
Fix Storybook type imports for Next.js build

### DIFF
--- a/src/components/EssentialPlaces.stories.tsx
+++ b/src/components/EssentialPlaces.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Meta, StoryObj } from '@storybook/react';
 import { FullDocumentPipeline } from './FullDocumentPipeline';
 import { essentialPlacesAnalysis } from './mocks/essential-places.mock';
 

--- a/src/components/FullDocumentPipeline.stories.tsx
+++ b/src/components/FullDocumentPipeline.stories.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Meta, StoryObj } from '@storybook/react';
 import { FullDocumentPipeline } from './FullDocumentPipeline';
 import { mouthsOfMadnessAnalysis } from './mocks/mouths-of-madness.mock';
 import type { DocumentAnalysisResult } from '@/types/document-pipeline';


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript/Next build error caused by importing `Meta`/`StoryObj` from a Storybook package that doesn't export them.
- Ensure Storybook story type imports are compatible with the project's environment to allow successful production builds.

### Description
- Replace `@storybook/nextjs-vite` with `@storybook/react` for story type imports in `EssentialPlaces.stories.tsx` and `FullDocumentPipeline.stories.tsx`.
- Remove an unused `React` import from `FullDocumentPipeline.stories.tsx` while keeping story definitions unchanged.
- This change addresses the `Module '"@storybook/nextjs-vite"' declares 'Meta' locally, but it is not exported` TypeScript error.

### Testing
- No automated tests or CI builds were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b934e49c832f90058f443a6bd2fe)