### PR TITLE
Fix canonical data number parsing for nullable fields

### DIFF
--- a/src/lib/canonical-data-mapper.ts
+++ b/src/lib/canonical-data-mapper.ts
@@ -13,7 +13,7 @@ export interface CanonicalData {
   notes?: string[];
 }
 
-function parseFirstNumber(value: string | undefined): number | null {
+function parseFirstNumber(value: string | null | undefined): number | null {
   if (!value) return null;
   const match = value.match(/\d+/);
   return match ? Number(match[0]) : null;


### PR DESCRIPTION
### Motivation
- The TypeScript build failed with an error saying a value of type `string | null` could not be passed to a function expecting `string | undefined`.
- `buildCanonicalData` can pass `null`/`undefined` field values such as `hpRaw` and `acRaw` into the numeric parser, so the parser must accept `null` inputs.
- Making the parser accept nullable inputs removes the compile-time error and makes the mapping of optional fields type-safe.
- This change prevents runtime/compile-time issues when fields are missing in parsed NPC data.

### Description
- Updated the signature of `parseFirstNumber` to accept `string | null | undefined` instead of only `string | undefined`.
- Left the parsing logic intact so `null`/`undefined` returns `null` and numbers are still extracted with `value.match(/\d+/)`.
- The change was applied in `src/lib/canonical-data-mapper.ts` where `hpRaw`/`acRaw` are passed through the parser.
- No other functional behavior was modified.

### Testing
- No automated tests were run for this change.
- The repository CI previously failed during `npm run build` / `next build` with the TypeScript error addressed by this change.
- Re-running the CI build or running `npm run build` locally is recommended to verify the TypeScript compile passes.
- If CI is re-run, the expectation is that the prior compile error related to `parseFirstNumber` will be resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695202815a94832f95baf61c1028405e)