### PR TITLE
Fix canonical mount lookup build error

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -207,14 +207,13 @@ export function lookupCanonicalMount(raw: string): MountBlock | undefined {
 
   return {
     name: canonical.name,
-    raw: block.raw ?? canonical.raw,
-    level: block.level ?? canonical.level,
-    hd: block.hd ?? canonical.hd,
-    hp: block.hp ?? canonical.hp,
-    ac: block.ac ?? canonical.ac,
-    disposition: block.disposition ?? canonical.disposition,
-    attacks: block.attacks ?? canonical.attacks,
-    equipment: block.equipment ?? canonical.equipment,
+    level: canonical.level,
+    hd: canonical.hd,
+    hp: canonical.hp,
+    ac: canonical.ac,
+    disposition: canonical.disposition,
+    attacks: canonical.attacks,
+    equipment: canonical.equipment,
   };
 }
 


### PR DESCRIPTION
### Motivation

- A TypeScript build error occurred due to use of an undefined identifier `block` inside `lookupCanonicalMount` which caused compilation to fail.  
- The intent is to return canonical mount data from the lookup helper so callers can merge with source `block` data safely.  
- Fixing this prevents the Next.js production build from failing on type-check.

### Description

- Remove the undefined `block` references from `lookupCanonicalMount` and return canonical fields directly (e.g. `level`, `hd`, `hp`, `ac`, `disposition`, `attacks`, `equipment`).  
- Keep `name` set to `canonical.name` in the lookup result so callers can identify the canonical entity.  
- Existing merging behavior remains in `canonicalizeMountBlock` where it uses `block.raw ?? canonical.raw` and similar merge logic to preserve source values when present.  

### Testing

- No automated tests were executed after this change.  
- CI/build was not re-run in this rollout, so recommend running `npm run build` or the project CI to validate the fix in the pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695209c9264c832f828f96cacfdcc826)