### PR TITLE
Fix undefined `block` in mount lookup and ensure `hasClassLevels` is defined before use

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -207,14 +207,14 @@ export function lookupCanonicalMount(raw: string): MountBlock | undefined {
 
   return {
     name: canonical.name,
-    raw: block.raw ?? canonical.raw,
-    level: block.level ?? canonical.level,
-    hd: block.hd ?? canonical.hd,
-    hp: block.hp ?? canonical.hp,
-    ac: block.ac ?? canonical.ac,
-    disposition: block.disposition ?? canonical.disposition,
-    attacks: block.attacks ?? canonical.attacks,
-    equipment: block.equipment ?? canonical.equipment,
+    raw: canonical.raw ?? raw,
+    level: canonical.level,
+    hd: canonical.hd,
+    hp: canonical.hp,
+    ac: canonical.ac,
+    disposition: canonical.disposition,
+    attacks: canonical.attacks,
+    equipment: canonical.equipment,
   };
 }
 
@@ -1431,6 +1431,27 @@ export function buildCanonicalParenthetical(
   formattingRules?: FormattingRules
 ): string {
   const parts: string[] = [];
+  // VERSION 3.0: Use V3 classifier to determine format
+  const v3Context: SignalExtractionContext = {
+    spells: data.spells,
+    raceClass: data.raceClass,
+    description: data.raw
+  };
+  const v3Classification = classifyEntityV3(title, {
+    name: data.name || title,
+    level: data.level,
+    hd: data.hd,
+    hp: data.hp ? parseInt(String(data.hp), 10) : null,
+    ac: data.ac ? parseInt(String(data.ac), 10) : null,
+    disposition: data.disposition,
+    primaryAttributes: data.attributes,
+    equipment: data.equipment,
+    coins: data.coins
+  }, v3Context);
+  
+  // Legacy compatibility
+  const classInfo = extractClassInfo(data.raceClass, data.level);
+  const hasClassLevels = classInfo.hasClassLevels || v3Classification.format === 'A';
   // Determine pronoun-based formatting early
   const pronounTrack: 'singular' | 'plural' = formattingRules?.pronounTrack ?? (isUnit ? 'plural' : 'singular');
   const possessiveSeed = formattingRules?.pronounPossessive ?? (hasClassLevels ? 'his' : 'its');
@@ -1463,27 +1484,7 @@ export function buildCanonicalParenthetical(
   let coinsIncludedInWeapons = false;
   let jewelryIncludedInEquipment = false;
   
-  // VERSION 3.0: Use V3 classifier to determine format
-  const v3Context: SignalExtractionContext = {
-    spells: data.spells,
-    raceClass: data.raceClass,
-    description: data.raw
-  };
-  const v3Classification = classifyEntityV3(title, {
-    name: data.name || title,
-    level: data.level,
-    hd: data.hd,
-    hp: data.hp ? parseInt(String(data.hp), 10) : null,
-    ac: data.ac ? parseInt(String(data.ac), 10) : null,
-    disposition: data.disposition,
-    primaryAttributes: data.attributes,
-    equipment: data.equipment,
-    coins: data.coins
-  }, v3Context);
   
-  // Legacy compatibility
-  const classInfo = extractClassInfo(data.raceClass, data.level);
-  const hasClassLevels = classInfo.hasClassLevels || v3Classification.format === 'A';
   const isNamedRanked = isRankedNamedEntity(title, data);
 
 


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript error where `lookupCanonicalMount` referenced an undefined `block` variable and returned incorrect fallback values.  
- Fix a compile-time error caused by `hasClassLevels` being used before its declaration inside `buildCanonicalParenthetical`.  
- Ensure pronoun selection and HD/HP formatting logic have the correct input values for V3 classification and legacy compatibility.  
- Preserve existing fallback semantics for canonicalization and avoid changing other call sites.

### Description
- Update `lookupCanonicalMount` to return canonical fields directly and use `raw: canonical.raw ?? raw` as the fallback instead of referencing `block`.  
- Move V3 classification (`classifyEntityV3`) and `extractClassInfo` earlier inside `buildCanonicalParenthetical` and compute `hasClassLevels` before pronoun selection.  
- Leave `canonicalizeMountBlock` behavior and other fallbacks unchanged.  
- Minor reordering of code to ensure `hasClassLevels` is available for subsequent formatting logic (HD/HP and pronoun handling).

### Testing
- A prior automated `next build` run failed with a TypeScript error: "Block-scoped variable 'hasClassLevels' used before its declaration" originating from `src/lib/enhanced-parser.ts`.  
- No automated tests or builds were run after these changes in this rollout.  
- No unit tests were added or modified for this change.  
- CI/build should be re-run to validate the fixes in a full automated build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695209c9264c832f828f96cacfdcc826)