### PR TITLE
Fix build failures: initialize V3 classifier early and tighten tsconfig excludes

### DIFF
--- a/src/lib/enhanced-parser.ts
+++ b/src/lib/enhanced-parser.ts
@@ -1430,6 +1430,30 @@ export function buildCanonicalParenthetical(
   formattingRules?: FormattingRules
 ): string {
   const parts: string[] = [];
+  const resolvedTitle = title ?? '';
+  // VERSION 3.0: Use V3 classifier to determine format
+  const v3Context: SignalExtractionContext = {
+    spells: data.spells,
+    raceClass: data.raceClass,
+    description: data.raw
+  };
+  const v3Classification = classifyEntityV3(resolvedTitle, {
+    name: resolvedTitle,
+    level: data.level ?? null,
+    hd: data.hd ?? null,
+    hp: data.hp ? parseInt(String(data.hp), 10) : null,
+    ac: data.ac ? parseInt(String(data.ac), 10) : null,
+    disposition: data.disposition ?? null,
+    primaryAttributes: data.attributes ?? null,
+    equipment: data.equipment ?? null,
+    coins: data.coins ?? null
+  }, v3Context);
+
+  // Legacy compatibility
+  const classInfo = extractClassInfo(data.raceClass, data.level);
+  const hasClassLevels = classInfo.hasClassLevels || v3Classification.format === 'A';
+  const isNamedRanked = isRankedNamedEntity(resolvedTitle, data);
+
   // Determine pronoun-based formatting early
   const pronounTrack: 'singular' | 'plural' = formattingRules?.pronounTrack ?? (isUnit ? 'plural' : 'singular');
   const possessiveSeed = formattingRules?.pronounPossessive ?? (hasClassLevels ? 'his' : 'its');
@@ -1462,30 +1486,6 @@ export function buildCanonicalParenthetical(
   let coinsIncludedInWeapons = false;
   let jewelryIncludedInEquipment = false;
   
-  // VERSION 3.0: Use V3 classifier to determine format
-  const v3Context: SignalExtractionContext = {
-    spells: data.spells,
-    raceClass: data.raceClass,
-    description: data.raw
-  };
-  const v3Classification = classifyEntityV3(title, {
-    name: data.name || title,
-    level: data.level,
-    hd: data.hd,
-    hp: data.hp ? parseInt(String(data.hp), 10) : null,
-    ac: data.ac ? parseInt(String(data.ac), 10) : null,
-    disposition: data.disposition,
-    primaryAttributes: data.attributes,
-    equipment: data.equipment,
-    coins: data.coins
-  }, v3Context);
-  
-  // Legacy compatibility
-  const classInfo = extractClassInfo(data.raceClass, data.level);
-  const hasClassLevels = classInfo.hasClassLevels || v3Classification.format === 'A';
-  const isNamedRanked = isRankedNamedEntity(title, data);
-
-
   // Build vital stats
   const vitalParts: string[] = [];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,9 @@
   ],
   "exclude": [
     "node_modules",
+    "tmp/**",
+    "tmp_*.ts",
+    "vite.config.ts",
     "**/*.stories.ts",
     "**/*.stories.tsx"
   ]


### PR DESCRIPTION
### Motivation
- Resolve TypeScript build-time errors caused by a use-before-declare ordering and mismatched optional types in the canonical parenthetical builder.
- Ensure the V3 classification stage has well-formed inputs so formatting logic (HP/HD selection, pronoun handling) can safely run during build.
- Prevent unrelated temporary/debug files and tooling configs from participating in Next.js type-checking and causing spurious failures.

### Description
- Moved V3 classification setup earlier inside `buildCanonicalParenthetical` and introduced `resolvedTitle` to avoid use-before-declare and undefined title issues in `src/lib/enhanced-parser.ts`.
- Normalized optional inputs passed to `classifyEntityV3` (coercing missing fields to `null`) and switched `isRankedNamedEntity` to use `resolvedTitle` for consistency.
- Removed the duplicated/late classifier block and updated downstream logic to rely on the early `v3Classification` result for HP/HD formatting decisions.
- Updated `tsconfig.json` `exclude` to ignore temporary/debug files and `vite.config.ts` so Next.js build type-checks don't fail on irrelevant artifacts.

### Testing
- Ran `npm run build` and the project compiled successfully with static pages generated and no blocking type errors.
- Build output included successful compilation and page optimization steps (static routes and shared chunks produced).
- ESLint/type warnings remained but did not block the production build (`npm run build` returned success).
- No unit tests were modified; `vitest` was not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69520e360420832f815ee159bf4770fa)