### PR TITLE
Fix unnecessary regex escape in disposition parsing

### DIFF
--- a/src/lib/stat-block-helpers.ts
+++ b/src/lib/stat-block-helpers.ts
@@ -40,7 +40,7 @@ export function normalizeDisposition(value: string): string {
   // If the input used explicit ordering (e.g., "good law" or "law/good"),
   // preserve the author's primary/secondary order when possible.
   const tokens = raw
-    .replace(/[\/]+/g, ' / ')
+    .replace(/\/+/g, ' / ')
     .split(/\s+/)
     .filter(Boolean)
     .map(t => t.trim());


### PR DESCRIPTION
### Motivation
- Fix a lint `no-useless-escape` error originating from an unnecessary escape in a regex used to split disposition tokens.
- Ensure the disposition normalization code is clearer and avoids false-positive lint failures.
- Allow the build/CI to proceed without being blocked by this lint error.

### Description
- Change `.replace(/[\/]+/g, ' / ')` to `.replace(/\/+/g, ' / ')` in `src/lib/stat-block-helpers.ts` within the `normalizeDisposition` implementation.
- The modification removes the unnecessary escape of `/` while preserving the behavior of collapsing consecutive slashes into a single spaced slash.
- The change is localized to `normalizeDisposition` token splitting and does not alter other logic.

### Testing
- No automated tests or CI runs were executed for this change.
- The repository previously failed `next build` due to the lint error this change addresses.
- This change should resolve the `no-useless-escape` lint failure so subsequent builds can proceed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521a09f354832f81d1b71bcd473432)