### PR TITLE
Fix Siege Engine attribute display

### DIFF
--- a/src/components/CharacterForge.tsx
+++ b/src/components/CharacterForge.tsx
@@ -2001,8 +2001,6 @@ export default function CharacterForge() {
                 {RULES.attributes.map(attr => {
                   const val = state.attributes[attr].score + (state.race.mods[attr as keyof RaceMod]||0);
                   const mod = RULES.getMod(val);
-                  const totalBonus = mod + state.level;
-                  const base = state.attributes[attr].prime ? 12 : 18;
 
                   return (
                     <div key={attr} className="flex justify-between items-center border-b border-dotted border-[#d6d3d1] last:border-0 py-1.5">
@@ -2011,22 +2009,15 @@ export default function CharacterForge() {
                         <span className={`font-bold text-base ${state.attributes[attr].prime ? 'text-[#292524]' : 'text-[#78716c]'}`}>
                             {attr}
                         </span>
-                        <span className="text-xs font-mono text-[#78716c]">[{state.attributes[attr].score}]</span>
+                        <span className="text-xs font-mono text-[#78716c]">[{val}]</span>
                       </div>
                       
                       <div className="text-right">
                         <div className="flex items-center gap-2 sm:gap-4">
                             <div className="flex flex-col items-end">
-                                <span className="text-[9px] text-[#a8a29e] uppercase leading-none font-bold">Bonus</span>
+                                <span className="text-[9px] text-[#a8a29e] uppercase leading-none font-bold">Mod</span>
                                 <span className="font-mono font-bold text-[#292524] text-lg">
-                                    {totalBonus >= 0 ? `+${totalBonus}` : totalBonus}
-                                </span>
-                            </div>
-
-                            <div className="flex flex-col items-end w-8">
-                                <span className="text-[9px] text-[#a8a29e] uppercase leading-none font-bold">Base</span>
-                                <span className={`font-mono font-bold text-lg ${state.attributes[attr].prime ? 'text-[#d97706]' : 'text-[#a8a29e]'}`}>
-                                    {base}
+                                    {mod >= 0 ? `+${mod}` : mod}
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- The Siege Engine panel mixed raw attribute score, modifiers, and Siege base values which produced impossible/incorrect displays.  
- It exposed a level-based "bonus" and a separate "base" column that conflated distinct C&C mechanics.  
- The goal is to present race-adjusted ability scores and true attribute modifiers separately so the UI matches Castles & Crusades rules.  

### Description
- Display the race-adjusted ability score (`val = state.attributes[attr].score + race.mods[...]`) instead of the unadjusted raw score.  
- Show the attribute modifier (`mod = RULES.getMod(val)`) labeled as `Mod` instead of the previous `Bonus` that included `level`.  
- Remove the misleading Siege `Base` column and the level-inclusive `totalBonus` calculation so attributes, modifiers, and prime status remain distinct.  
- Changes were made in `src/components/CharacterForge.tsx` (Siege Engine panel rendering).  

### Testing
- Started the dev server with `npm run dev` and the application compiled successfully.  
- The root page loaded (HTTP 200) and a Playwright screenshot was captured to validate the Siege Engine UI (`artifacts/siege-engine-mod.png`).  
- No unit tests were added or modified for this change.  
- The change was committed to the local branch (`Fix siege engine attribute display`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695391e353c8832f8cbf3c85c262fa00)